### PR TITLE
New features: Project Notebooks + Quick Inspect objects

### DIFF
--- a/DLPrototype.xcodeproj/project.pbxproj
+++ b/DLPrototype.xcodeproj/project.pbxproj
@@ -223,6 +223,19 @@
 		};
 /* End PBXContainerItemProxy section */
 
+/* Begin PBXCopyFilesBuildPhase section */
+		537DFF9E2BF2A2C900FC5923 /* Embed Foundation Extensions */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 13;
+			files = (
+			);
+			name = "Embed Foundation Extensions";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
 /* Begin PBXFileReference section */
 		530168162A887B0A000AF4FD /* AllJobsPickerWidget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AllJobsPickerWidget.swift; sourceTree = "<group>"; };
 		530318462A11DD13009CA90B /* CoreDataCalendarEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreDataCalendarEvent.swift; sourceTree = "<group>"; };
@@ -351,6 +364,8 @@
 		537AEB9E29627DCC00385787 /* LogTable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogTable.swift; sourceTree = "<group>"; };
 		537AEBA0296287B900385787 /* LogRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogRow.swift; sourceTree = "<group>"; };
 		537DFF862BF27F0B00FC5923 /* PRIVACY.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = PRIVACY.md; sourceTree = "<group>"; };
+		537DFF8C2BF2A2C800FC5923 /* WidgetKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WidgetKit.framework; path = System/Library/Frameworks/WidgetKit.framework; sourceTree = SDKROOT; };
+		537DFF8E2BF2A2C800FC5923 /* SwiftUI.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SwiftUI.framework; path = System/Library/Frameworks/SwiftUI.framework; sourceTree = SDKROOT; };
 		53814A8A2A95151000A5A015 /* CoreDataPlan.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreDataPlan.swift; sourceTree = "<group>"; };
 		53814A8D2A9821C800A5A015 /* DefaultPlanningSidebar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultPlanningSidebar.swift; sourceTree = "<group>"; };
 		53842B262B4C82B20029AC73 /* Project.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Project.swift; sourceTree = "<group>"; };
@@ -1138,6 +1153,8 @@
 			isa = PBXGroup;
 			children = (
 				53F0C70C2BF04625000BFD2E /* CoreSpotlight.framework */,
+				537DFF8C2BF2A2C800FC5923 /* WidgetKit.framework */,
+				537DFF8E2BF2A2C800FC5923 /* SwiftUI.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -1152,6 +1169,7 @@
 				53218D4024B7F6EB0088ABE9 /* Sources */,
 				53218D4124B7F6EB0088ABE9 /* Frameworks */,
 				53218D4224B7F6EB0088ABE9 /* Resources */,
+				537DFF9E2BF2A2C900FC5923 /* Embed Foundation Extensions */,
 			);
 			buildRules = (
 			);
@@ -1210,7 +1228,7 @@
 				KnownAssetTags = (
 					New,
 				);
-				LastSwiftUpdateCheck = 1150;
+				LastSwiftUpdateCheck = 1530;
 				LastUpgradeCheck = 1510;
 				ORGANIZATIONNAME = YegCollective;
 				TargetAttributes = {
@@ -1713,11 +1731,11 @@
 					"@executable_path/../Frameworks",
 					"@loader_path/../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 10.15;
+				MACOSX_DEPLOYMENT_TARGET = 13.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.yegcollective.DLPrototypeTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/DLPrototype.app/Contents/MacOS/DLPrototype";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/ClockWork.Beta.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/ClockWork.Beta";
 			};
 			name = Debug;
 		};
@@ -1736,11 +1754,11 @@
 					"@executable_path/../Frameworks",
 					"@loader_path/../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 10.15;
+				MACOSX_DEPLOYMENT_TARGET = 13.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.yegcollective.DLPrototypeTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/DLPrototype.app/Contents/MacOS/DLPrototype";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/ClockWork.Beta.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/ClockWork.Beta";
 			};
 			name = Release;
 		};

--- a/DLPrototype/Models/CoreData/CoreDataCompanies.swift
+++ b/DLPrototype/Models/CoreData/CoreDataCompanies.swift
@@ -32,6 +32,20 @@ public class CoreDataCompanies: ObservableObject {
 
         return FetchRequest(fetchRequest: fetch, animation: .easeInOut)
     }
+    
+    /// Finds all active companies
+    /// - Returns: FetchRequest<Company>
+    static public func fetch() -> FetchRequest<Company> {
+        let descriptors = [
+            NSSortDescriptor(keyPath: \Company.name?, ascending: true)
+        ]
+
+        let fetch: NSFetchRequest<Company> = Company.fetchRequest()
+        fetch.predicate = NSPredicate(format: "alive = true")
+        fetch.sortDescriptors = descriptors
+
+        return FetchRequest(fetchRequest: fetch, animation: .easeInOut)
+    }
 
     public func byPid(_ id: Int) -> Company? {
         let predicate = NSPredicate(

--- a/DLPrototype/Utils/Navigation.swift
+++ b/DLPrototype/Utils/Navigation.swift
@@ -109,6 +109,7 @@ public class Navigation: Identifiable, ObservableObject {
 //        view = AnyView(WidgetLoading())
 //        state.on(.complete, { _ in
             view = newView
+            forms.tp.clear()
 //        })
 //        if state.phase == .complete {
 //            
@@ -207,7 +208,7 @@ extension Navigation {
     // @TODO: remove from Navigation
     public struct Forms {
         var note: NoteForm = NoteForm()
-        var jobSelector: JobSelectorForm = JobSelectorForm()
+        var tp: ThreePanelForm = ThreePanelForm()
 
         struct NoteForm {
             var template: NoteTemplates.Template? = nil
@@ -216,11 +217,11 @@ extension Navigation {
             var star: Bool = false
         }
         
-        struct JobSelectorForm {
+        struct ThreePanelForm {
             var currentPosition: Panel.Position = .first
             var first: FetchedResults<Company>? = nil
             var middle: [Project] = []
-            var last: [Job] = []
+            var last: [NSManagedObject] = []
             var selected: [Panel.SelectedValueCoordinates] = []
             var editor: Editor = Editor()
 
@@ -228,6 +229,13 @@ extension Navigation {
                 var job: Job? = nil
                 var jid: String? = ""
                 var title: String? = ""
+            }
+
+            mutating public func clear() -> Void {
+                self.currentPosition = .first
+                self.middle = []
+                self.last = []
+                self.selected = []
             }
         }
 

--- a/DLPrototype/Utils/Navigation.swift
+++ b/DLPrototype/Utils/Navigation.swift
@@ -561,14 +561,6 @@ extension Navigation.Session {
         var moc: NSManagedObjectContext
         var hasResults: Bool = false
         var inspectingEntity: NSManagedObject? = nil
-        
-        mutating func inspect(_ obj: NSManagedObject) -> Void {
-            inspectingEntity = obj
-        }
-        
-        mutating func cancel() -> Void {
-            inspectingEntity = nil
-        }
     }
     
     public struct Toolbar: Identifiable {
@@ -586,12 +578,23 @@ extension Navigation.Session.Search {
         
         return SearchLanguage.Results(components: components, moc: moc).find()
     }
-    
+
+    // @TODO: do we need this AND cancel?
     mutating func reset() -> Void {
         components = []
         text = nil
         hasResults = false
         inspectingEntity = nil
+    }
+
+    // @TODO: do we need this AND reset?
+    mutating func cancel() -> Void {
+        inspectingEntity = nil
+        text = nil
+    }
+
+    mutating func inspect(_ obj: NSManagedObject) -> Void {
+        inspectingEntity = obj
     }
 }
 

--- a/DLPrototype/Utils/Navigation.swift
+++ b/DLPrototype/Utils/Navigation.swift
@@ -110,6 +110,7 @@ public class Navigation: Identifiable, ObservableObject {
 //        state.on(.complete, { _ in
             view = newView
             forms.tp.clear()
+            setInspector()
 //        })
 //        if state.phase == .complete {
 //            

--- a/DLPrototype/Views/Entities/Jobs/JobDashboard.swift
+++ b/DLPrototype/Views/Entities/Jobs/JobDashboard.swift
@@ -111,7 +111,7 @@ struct JobDashboardRedux: View {
                             newJob.overview = "Edit this description"
                             newJob.title = "Sample job title"
                             nav.session.job = newJob
-                            nav.forms.jobSelector.editor.job = newJob
+                            nav.forms.tp.editor.job = newJob
                         },
                         icon: "plus",
                         showLabel: false
@@ -166,7 +166,7 @@ struct JobExplorer: View {
             .foregroundStyle(.white)
             
             if explorerVisible {
-                ThreePanelGroup(orientation: .horizontal, data: companies)
+                ThreePanelGroup(orientation: .horizontal, data: companies, lastColumnType: .jobs)
             }
             
             VStack(alignment: .leading, spacing: 1) {

--- a/DLPrototype/Views/Entities/Notes/NoteDashboard.swift
+++ b/DLPrototype/Views/Entities/Notes/NoteDashboard.swift
@@ -38,8 +38,8 @@ struct NoteDashboard: View {
 
         let sharedDescriptors = [
             NSSortDescriptor(keyPath: \Note.lastUpdate?, ascending: false),
-            NSSortDescriptor(keyPath: \Note.mJob?.project?.id, ascending: false),
-            NSSortDescriptor(keyPath: \Note.mJob?.id, ascending: false),
+            NSSortDescriptor(keyPath: \Note.mJob?.project?.pid, ascending: true),
+            NSSortDescriptor(keyPath: \Note.mJob?.jid, ascending: true),
             NSSortDescriptor(keyPath: \Note.title, ascending: true)
         ]
         

--- a/DLPrototype/Views/Entities/Notes/NoteDashboard.swift
+++ b/DLPrototype/Views/Entities/Notes/NoteDashboard.swift
@@ -116,7 +116,13 @@ struct NoteDashboard: View {
                         placeholder: notes.count > 1 ? "Search \(notes.count) notes" : "Search 1 note"
                     )
 
-                    recentNotes
+                    ScrollView(showsIndicators: false) {
+                        LazyVGrid(columns: columns, alignment: .leading) {
+                            ForEach(filter(notes)) { note in
+                                NoteBlock(note: note)
+                            }
+                        }
+                    }
                 }
 
                 Spacer()
@@ -124,68 +130,6 @@ struct NoteDashboard: View {
             .padding()
         }
         .background(Theme.toolbarColour)
-    }
-
-    @ViewBuilder private var recentNotes: some View {
-        if notes.count > 0 {
-            ScrollView(showsIndicators: false) {
-                LazyVGrid(columns: columns, alignment: .leading) {
-                    ForEach(filter(notes)) { note in
-                        NoteBlock(note: note)
-                            .environmentObject(nav)
-                            .environmentObject(jm)
-                            .environmentObject(updater)
-                    }
-                }
-            }
-        } else {
-            Text("No notes for this query")
-        }
-    }
-
-    // TODO: keep this, but make it optional
-    @ViewBuilder
-    var allTable: some View {
-        Grid(horizontalSpacing: 1, verticalSpacing: 1) {
-            HStack(spacing: 0) {
-                GridRow {
-                    Group {
-                        ZStack(alignment: .leading) {
-                            Theme.headerColour
-                            Text("Name")
-                                .padding()
-                        }
-                    }
-                    Group {
-                        ZStack {
-                            Theme.headerColour
-                            Text("Versions")
-                                .padding()
-                        }
-                    }
-                    .frame(width: 100)
-                }
-            }
-            .frame(height: 46)
-            
-            allRows
-        }
-        .font(Theme.font)
-    }
-    
-    @ViewBuilder
-    var allRows: some View {
-        ScrollView(showsIndicators: false) {
-            if notes.count > 0 {
-                VStack(alignment: .leading, spacing: 1) {
-                    ForEach(filter(notes)) { note in
-                        NoteRow(note: note)
-                    }
-                }
-            } else {
-                Text("No notes for this query")
-            }
-        }
     }
 }
 

--- a/DLPrototype/Views/Entities/Notes/NoteDashboard.swift
+++ b/DLPrototype/Views/Entities/Notes/NoteDashboard.swift
@@ -99,7 +99,7 @@ struct NoteDashboard: View {
                     }
 
                     HStack {
-                        Text("Your notes, last updated first.")
+                        Text("Notes are sorted from most to least recently updated.")
                             .font(.caption)
                         Spacer()
                     }
@@ -146,7 +146,7 @@ extension NoteDashboard {
         @FetchRequest public var companies: FetchedResults<Company>
 
         var body: some View {
-            VStack(alignment: .leading, spacing: 0) {
+            VStack(alignment: .leading, spacing: 1) {
                 VStack(alignment: .leading, spacing: 1) {
                     HStack {
                         Text("Project Notebooks").font(.title2)

--- a/DLPrototype/Views/Entities/Notes/NoteRowPlain.swift
+++ b/DLPrototype/Views/Entities/Notes/NoteRowPlain.swift
@@ -13,6 +13,8 @@ struct NoteRowPlain: View {
     public var moc: NSManagedObjectContext
     public var icon: String = "arrow.right"
 
+    @AppStorage("CreateEntitiesWidget.isSearchStackShowing") private var isSearching: Bool = false
+
     @EnvironmentObject public var nav: Navigation
 
     var body: some View {
@@ -34,6 +36,15 @@ struct NoteRowPlain: View {
                         pageType: .notes,
                         sidebar: AnyView(NoteCreateSidebar(note: note))
                     )
+                    .contextMenu {
+                        Button(action: {
+                            isSearching = true
+                            nav.setInspector(AnyView(Inspector(entity: note)))
+                            nav.session.search.text = note.title
+                        }, label: {
+                            Text("Inspect")
+                        })
+                    }
                 }
                 Spacer()
             }

--- a/DLPrototype/Views/Find/FindDashboard.swift
+++ b/DLPrototype/Views/Find/FindDashboard.swift
@@ -32,6 +32,8 @@ struct FindDashboard: View {
     @StateObject public var jm: CoreDataJob = CoreDataJob(moc: PersistenceController.shared.container.viewContext)
     @EnvironmentObject public var nav: Navigation
 
+    
+
     private var columns: [GridItem] {
         Array(repeating: .init(.flexible(minimum: 100)), count: 2)
     }
@@ -175,6 +177,7 @@ struct FindDashboard: View {
             }
         }
         .onChange(of: nav.session.search.inspectingEntity) { entity in
+
             if location == .sidebar {
                 if entity != nil {
                     nav.setInspector(AnyView(Inspector(entity: entity!)))
@@ -232,10 +235,11 @@ extension FindDashboard {
                 CoreDataTasks(moc: moc).countAll(),
                 CoreDataProjects(moc: moc).countAll()
             )
+            showingTypes = true
         }
 
-        if location == .content {
-            showingTypes = true
+        if nav.session.search.text != nil {
+            activeSearchText = nav.session.search.text!
         }
     }
     

--- a/DLPrototype/Views/Find/FindDashboard.swift
+++ b/DLPrototype/Views/Find/FindDashboard.swift
@@ -32,8 +32,6 @@ struct FindDashboard: View {
     @StateObject public var jm: CoreDataJob = CoreDataJob(moc: PersistenceController.shared.container.viewContext)
     @EnvironmentObject public var nav: Navigation
 
-    
-
     private var columns: [GridItem] {
         Array(repeating: .init(.flexible(minimum: 100)), count: 2)
     }
@@ -176,8 +174,12 @@ struct FindDashboard: View {
                 onReset()
             }
         }
+        .onChange(of: nav.session.search.text) { searchQuery in
+            if let sq = searchQuery {
+                activeSearchText = sq
+            }
+        }
         .onChange(of: nav.session.search.inspectingEntity) { entity in
-
             if location == .sidebar {
                 if entity != nil {
                     nav.setInspector(AnyView(Inspector(entity: entity!)))
@@ -196,7 +198,13 @@ extension FindDashboard {
         } else {
             searching = false
         }
-        
+
+        if nav.session.search.inspectingEntity != nil {
+            if let stext = nav.session.search.text {
+                activeSearchText = stext
+            }
+        }
+
         // Search appearing in other views should only provide suggestions due to lack of visual space
         if location == .content {
             if searching {

--- a/DLPrototype/Views/Find/Inspector/Context.swift
+++ b/DLPrototype/Views/Find/Inspector/Context.swift
@@ -8,7 +8,7 @@
 
 import SwiftUI
 
-extension FindDashboard.Inspector {
+extension Inspector {
     public struct Context<T>: View {
         public var item: T
         // @TODO: refactor these vars into more structs (there will be dozens of these here once all entities are supported)
@@ -19,7 +19,7 @@ extension FindDashboard.Inspector {
         @Environment(\.managedObjectContext) var moc
         @EnvironmentObject private var nav: Navigation
 
-        var body: some View {
+        public var body: some View {
             VStack(alignment: .leading) {
                 FancyDivider()
                 HStack(alignment: .top) {
@@ -174,7 +174,7 @@ extension FindDashboard.Inspector {
     }
 }
 
-extension FindDashboard.Inspector.Context {
+extension Inspector.Context {
     private func actionOnClick(_ day: Date) -> Void {
         nav.session.date = day
         nav.session.search.cancel()

--- a/DLPrototype/Views/Find/Inspector/Context.swift
+++ b/DLPrototype/Views/Find/Inspector/Context.swift
@@ -44,7 +44,10 @@ extension Inspector {
                                         icon: "arrow.right.square.fill",
                                         fgColour: .white,
                                         showIcon: true,
-                                        size: .link
+                                        size: .link,
+                                        redirect: AnyView(Today()),
+                                        pageType: .today,
+                                        sidebar: AnyView(TodaySidebar())
                                     )
                                     .help("Open day")
                                 }
@@ -178,6 +181,7 @@ extension Inspector.Context {
     private func actionOnClick(_ day: Date) -> Void {
         nav.session.date = day
         nav.session.search.cancel()
+        nav.setInspector()
     }
 
     private func actionShowPlan(_ day: Date) -> Void {

--- a/DLPrototype/Views/Find/Inspector/Inspector.swift
+++ b/DLPrototype/Views/Find/Inspector/Inspector.swift
@@ -8,279 +8,101 @@
 
 import SwiftUI
 
-extension FindDashboard {
-    struct Inspector: View, Identifiable {
-        public let id: UUID = UUID()
-        public var entity: NSManagedObject
-        
-        private let panelWidth: CGFloat = 400
-        private var job: Job? = nil
-        private var project: Project? = nil
-        private var record: LogRecord? = nil
-        private var company: Company? = nil
-        private var person: Person? = nil
-        private var note: Note? = nil
-        private var task: LogTask? = nil
-        
-        @EnvironmentObject public var nav: Navigation
-        
-        var body: some View {
-            VStack(alignment: .leading) {
-                HStack {
-                    FancySubTitle(text: "Inspector")
-                    Spacer()
-                    FancyButtonv2(
-                        text: "Close",
-                        action: {nav.session.search.cancel()},
-                        icon: "xmark",
-                        showLabel: false,
-                        size: .tiny,
-                        type: .clear
-                    )
-                }
-                Divider()
-                    .padding(.bottom, 10)
-                
-                if let job = job {
-                    InspectingJob(item: job)
-                } else if let record = record {
-                    InspectingRecord(item: record)
-                } else if let project = project {
-                    InspectingProject(item: project)
-                } else if let company = company {
-                    InspectingCompany(item: company)
-                } else if let person = person {
-                    InspectingPerson(item: person)
-                } else if let note = note {
-                    InspectingNote(item: note)
-                } else if let task = task {
-                    InspectingTask(item: task)
-                } else {
-                    Text("Unable to inspect this item")
-                }
-                Spacer()
-            }
-            .padding()
-            .frame(maxWidth: panelWidth)
-        }
-        
-        init(entity: NSManagedObject) {
-            self.entity = entity
-            
-            switch self.entity {
-            case let en as Job: self.job = en
-            case let en as Project: self.project = en
-            case let en as LogRecord: self.record = en
-            case let en as Company: self.company = en
-            case let en as Person: self.person = en
-            case let en as Note: self.note = en
-            case let en as LogTask: self.task = en
-            default: print("[error] FindDashboard.Inspector Unknown entity type=\(self.entity)")
-            }
-        }
 
-        struct InspectingJob: View {
-            public var item: Job
-            
-            @EnvironmentObject public var nav: Navigation
-            
-            var body: some View {
-                ScrollView {
-                    VStack(alignment: .leading, spacing: 10) {
-                        HStack(alignment: .top, spacing: 10) {
-                            Image(systemName: "questionmark.square.fill").symbolRenderingMode(.hierarchical)
-                            Text("Type: Job")
-                            Spacer()
-                        }
-                        .help("Type: Job entity")
-                        Divider()
-                        
-                        HStack(alignment: .top, spacing: 10) {
-                            Image(systemName: "number").symbolRenderingMode(.hierarchical)
-                            Text(item.jid.string)
-                            Spacer()
-                        }
-                        .help("ID: \(item.jid.string)")
-                        Divider()
-                        
-                        if let date = item.created {
-                            HStack(alignment: .top, spacing: 10) {
-                                Image(systemName: "calendar.badge.plus").symbolRenderingMode(.hierarchical)
-                                Text(date.description)
-                                Spacer()
-                            }
-                            .help("Created: \(date.description)")
-                            Divider()
-                        }
-                        
-                        if let date = item.lastUpdate {
-                            HStack(alignment: .top, spacing: 10) {
-                                Image(systemName: "calendar.badge.clock").symbolRenderingMode(.hierarchical)
-                                Text(date.description)
-                                Spacer()
-                            }
-                            .help("Last updated: \(date.description)")
-                            Divider()
-                        }
-                        
-                        if let uri = item.uri {
-                            VStack(alignment: .leading) {
-                                HStack(alignment: .top, spacing: 10) {
-                                    Image(systemName: "link").symbolRenderingMode(.hierarchical)
-                                    Link(destination: uri, label: {
-                                        Text(uri.absoluteString)
-                                    })
-                                    .help("Open in browser")
-                                    .underline()
-                                    .useDefaultHover({_ in})
-                                    .contextMenu {
-                                        Button {
-                                            ClipboardHelper.copy(uri.absoluteString)
-                                        } label: {
-                                            Text("Copy to clipboard")
-                                        }
-                                    }
-                                    Spacer()
-                                }
-                                Divider()
-                            }
-                        }
-                        
-                        HStack(alignment: .top, spacing: 10) {
-                            Image(systemName: "camera.filters").symbolRenderingMode(.hierarchical)
-                            ZStack {
-                                Theme.base
-                                item.colour_from_stored()
-                            }
-                            .frame(width: 15, height: 15)
-                            Text(item.colour_from_stored().description)
-                                .contextMenu {
-                                    Button {
-                                        ClipboardHelper.copy(item.colour_from_stored().description)
-                                    } label: {
-                                        Text("Copy colour HEX to clipboard")
-                                    }
-                                }
-                            Spacer()
-                        }
-                        .help("Colour: \(item.colour_from_stored().description)")
-                        Divider()
-                        
-                        Context(item: item)
-                        
-                        Spacer()
-                        VStack(alignment: .leading) {
-                            HStack(alignment: .top, spacing: 10) {
-                                FancyButtonv2(
-                                    text: "Open",
-                                    action: {nav.session.search.cancel()},
-                                    icon: "arrow.right.square.fill",
-                                    showLabel: true,
-                                    size: .link,
-                                    type: .clear,
-                                    redirect: AnyView(JobDashboard(defaultSelectedJob: item)),
-                                    pageType: .jobs,
-                                    sidebar: AnyView(JobDashboardSidebar())
-                                )
-                                
-                                FancyButtonv2(
-                                    text: nav.session.job != nil ?
-                                    (
-                                        nav.session.job == item ? "Current job" : "Overwrite Active Job"
-                                    ):
-                                        "Set to Active Job",
-                                    action: {nav.session.job = item},
-                                    icon: "arrow.right.square.fill",
-                                    showLabel: true,
-                                    size: .link,
-                                    type: .clear
-                                )
-                                .disabled(nav.session.job == item)
-                                .help(nav.session.job != nil ? "Current: \(nav.session.job!.jid)" : "Flags this as the current job on other pages and in widgets.")
-                            }
-                        }
-                    }
-                }
+public struct Inspector: View, Identifiable {
+    public let id: UUID = UUID()
+    public var entity: NSManagedObject
+
+    private let panelWidth: CGFloat = 400
+    private var job: Job? = nil
+    private var project: Project? = nil
+    private var record: LogRecord? = nil
+    private var company: Company? = nil
+    private var person: Person? = nil
+    private var note: Note? = nil
+    private var task: LogTask? = nil
+
+    @EnvironmentObject public var nav: Navigation
+
+    public var body: some View {
+        VStack(alignment: .leading) {
+            HStack {
+                FancySubTitle(text: "Inspector")
+                Spacer()
+                FancyButtonv2(
+                    text: "Close",
+                    action: {nav.session.search.cancel() ; nav.setInspector()},
+                    icon: "xmark",
+                    showLabel: false,
+                    size: .tiny,
+                    type: .clear
+                )
             }
+            Divider()
+                .padding(.bottom, 10)
+
+            if let job = job {
+                InspectingJob(item: job)
+            } else if let record = record {
+                InspectingRecord(item: record)
+            } else if let project = project {
+                InspectingProject(item: project)
+            } else if let company = company {
+                InspectingCompany(item: company)
+            } else if let person = person {
+                InspectingPerson(item: person)
+            } else if let note = note {
+                InspectingNote(item: note)
+            } else if let task = task {
+                InspectingTask(item: task)
+            } else {
+                Text("Unable to inspect this item")
+            }
+            Spacer()
         }
-        
-        struct InspectingRecord: View {
-            public var item: LogRecord
-            
-            @EnvironmentObject public var nav: Navigation
-            
-            var body: some View {
+        .padding()
+        .frame(maxWidth: panelWidth)
+    }
+
+    init(entity: NSManagedObject) {
+        self.entity = entity
+
+        switch self.entity {
+        case let en as Job: self.job = en
+        case let en as Project: self.project = en
+        case let en as LogRecord: self.record = en
+        case let en as Company: self.company = en
+        case let en as Person: self.person = en
+        case let en as Note: self.note = en
+        case let en as LogTask: self.task = en
+        default: print("[error] FindDashboard.Inspector Unknown entity type=\(self.entity)")
+        }
+    }
+
+    struct InspectingJob: View {
+        public var item: Job
+
+        @EnvironmentObject public var nav: Navigation
+
+        var body: some View {
+            ScrollView {
                 VStack(alignment: .leading, spacing: 10) {
                     HStack(alignment: .top, spacing: 10) {
                         Image(systemName: "questionmark.square.fill").symbolRenderingMode(.hierarchical)
-                        Text("Type: Record")
+                        Text("Type: Job")
                         Spacer()
                     }
-                    .help("Type: Record entity")
+                    .help("Type: Job entity")
                     Divider()
-                    
-                    if let date = item.timestamp {
-                        HStack(alignment: .top, spacing: 10) {
-                            Image(systemName: "calendar.badge.plus").symbolRenderingMode(.hierarchical)
-                            Text(date.description)
-                            Spacer()
-                        }
-                        .help("Created: \(date.description)")
-                        Divider()
-                    }
-                    
-                    if let message = item.message {
-                        HStack(alignment: .top, spacing: 10) {
-                            Image(systemName: "doc.text.fill").symbolRenderingMode(.hierarchical)
-                            Text("Full message:")
-                            Spacer()
-                        }
-                        Divider()
-                        Text(message)
-                            .padding(.leading, 25)
-                            .contextMenu {
-                                Button("Copy") {
-                                    ClipboardHelper.copy(message)
-                                }
-                            }
-                            .help("Full contents of this message")
-                    }
-                    
-                    Divider()
-                    
-                    Spacer()
+
                     HStack(alignment: .top, spacing: 10) {
-                        FancyButtonv2(
-                            text: "Open day",
-                            action: {nav.session.date = item.timestamp ?? Date()},
-                            icon: "arrow.right.square.fill",
-                            showLabel: true,
-                            size: .link,
-                            type: .clear,
-                            redirect: AnyView(Today()),
-                            pageType: .today,
-                            sidebar: AnyView(TodaySidebar())
-                        )
-                    }
-                }
-            }
-        }
-        
-        struct InspectingProject: View {
-            public var item: Project
-            
-            @EnvironmentObject public var nav: Navigation
-            
-            var body: some View {
-                VStack(alignment: .leading, spacing: 10) {
-                    HStack(alignment: .top, spacing: 10) {
-                        Image(systemName: "questionmark.square.fill").symbolRenderingMode(.hierarchical)
-                        Text("Type: Project")
+                        Image(systemName: "number").symbolRenderingMode(.hierarchical)
+                        Text(item.jid.string)
                         Spacer()
                     }
-                    .help("Type: Project entity")
+                    .help("ID: \(item.jid.string)")
                     Divider()
-                    
+
                     if let date = item.created {
                         HStack(alignment: .top, spacing: 10) {
                             Image(systemName: "calendar.badge.plus").symbolRenderingMode(.hierarchical)
@@ -290,60 +112,195 @@ extension FindDashboard {
                         .help("Created: \(date.description)")
                         Divider()
                     }
-                    
+
+                    if let date = item.lastUpdate {
+                        HStack(alignment: .top, spacing: 10) {
+                            Image(systemName: "calendar.badge.clock").symbolRenderingMode(.hierarchical)
+                            Text(date.description)
+                            Spacer()
+                        }
+                        .help("Last updated: \(date.description)")
+                        Divider()
+                    }
+
+                    if let uri = item.uri {
+                        VStack(alignment: .leading) {
+                            HStack(alignment: .top, spacing: 10) {
+                                Image(systemName: "link").symbolRenderingMode(.hierarchical)
+                                Link(destination: uri, label: {
+                                    Text(uri.absoluteString)
+                                })
+                                .help("Open in browser")
+                                .underline()
+                                .useDefaultHover({_ in})
+                                .contextMenu {
+                                    Button {
+                                        ClipboardHelper.copy(uri.absoluteString)
+                                    } label: {
+                                        Text("Copy to clipboard")
+                                    }
+                                }
+                                Spacer()
+                            }
+                            Divider()
+                        }
+                    }
+
+                    HStack(alignment: .top, spacing: 10) {
+                        Image(systemName: "camera.filters").symbolRenderingMode(.hierarchical)
+                        ZStack {
+                            Theme.base
+                            item.colour_from_stored()
+                        }
+                        .frame(width: 15, height: 15)
+                        Text(item.colour_from_stored().description)
+                            .contextMenu {
+                                Button {
+                                    ClipboardHelper.copy(item.colour_from_stored().description)
+                                } label: {
+                                    Text("Copy colour HEX to clipboard")
+                                }
+                            }
+                        Spacer()
+                    }
+                    .help("Colour: \(item.colour_from_stored().description)")
+                    Divider()
+
+                    Context(item: item)
+
                     Spacer()
-                    if let company = item.company {
+                    VStack(alignment: .leading) {
                         HStack(alignment: .top, spacing: 10) {
                             FancyButtonv2(
-                                text: "Open project",
+                                text: "Open",
+                                action: {nav.session.search.cancel() ; nav.setInspector()},
                                 icon: "arrow.right.square.fill",
                                 showLabel: true,
                                 size: .link,
                                 type: .clear,
-                                redirect: AnyView(CompanyDashboard(company: company)),
-                                pageType: .companies,
-                                sidebar: AnyView(DefaultCompanySidebar())
+                                redirect: AnyView(JobDashboard(defaultSelectedJob: item)),
+                                pageType: .jobs,
+                                sidebar: AnyView(JobDashboardSidebar())
                             )
+
+                            FancyButtonv2(
+                                text: nav.session.job != nil ?
+                                (
+                                    nav.session.job == item ? "Current job" : "Overwrite Active Job"
+                                ):
+                                    "Set to Active Job",
+                                action: {nav.session.job = item},
+                                icon: "arrow.right.square.fill",
+                                showLabel: true,
+                                size: .link,
+                                type: .clear
+                            )
+                            .disabled(nav.session.job == item)
+                            .help(nav.session.job != nil ? "Current: \(nav.session.job!.jid)" : "Flags this as the current job on other pages and in widgets.")
                         }
                     }
                 }
             }
         }
-        
-        struct InspectingCompany: View {
-            public var item: Company
-            
-            @EnvironmentObject public var nav: Navigation
-            
-            var body: some View {
-                VStack(alignment: .leading, spacing: 10) {
+    }
+
+    struct InspectingRecord: View {
+        public var item: LogRecord
+
+        @EnvironmentObject public var nav: Navigation
+
+        var body: some View {
+            VStack(alignment: .leading, spacing: 10) {
+                HStack(alignment: .top, spacing: 10) {
+                    Image(systemName: "questionmark.square.fill").symbolRenderingMode(.hierarchical)
+                    Text("Type: Record")
+                    Spacer()
+                }
+                .help("Type: Record entity")
+                Divider()
+
+                if let date = item.timestamp {
                     HStack(alignment: .top, spacing: 10) {
-                        Image(systemName: "questionmark.square.fill").symbolRenderingMode(.hierarchical)
-                        Text("Type: Company")
+                        Image(systemName: "calendar.badge.plus").symbolRenderingMode(.hierarchical)
+                        Text(date.description)
                         Spacer()
                     }
-                    .help("Type: Company entity")
+                    .help("Created: \(date.description)")
                     Divider()
-                    
-                    if let date = item.createdDate {
-                        HStack(alignment: .top, spacing: 10) {
-                            Image(systemName: "calendar.badge.plus").symbolRenderingMode(.hierarchical)
-                            Text(date.description)
-                            Spacer()
-                        }
-                        .help("Created: \(date.description)")
-                        Divider()
+                }
+
+                if let message = item.message {
+                    HStack(alignment: .top, spacing: 10) {
+                        Image(systemName: "doc.text.fill").symbolRenderingMode(.hierarchical)
+                        Text("Full message:")
+                        Spacer()
                     }
-                    
+                    Divider()
+                    Text(message)
+                        .padding(.leading, 25)
+                        .contextMenu {
+                            Button("Copy") {
+                                ClipboardHelper.copy(message)
+                            }
+                        }
+                        .help("Full contents of this message")
+                }
+
+                Divider()
+
+                Spacer()
+                HStack(alignment: .top, spacing: 10) {
+                    FancyButtonv2(
+                        text: "Open day",
+                        action: {nav.session.date = item.timestamp ?? Date() ; nav.setInspector()},
+                        icon: "arrow.right.square.fill",
+                        showLabel: true,
+                        size: .link,
+                        type: .clear,
+                        redirect: AnyView(Today()),
+                        pageType: .today,
+                        sidebar: AnyView(TodaySidebar())
+                    )
+                }
+            }
+        }
+    }
+
+    struct InspectingProject: View {
+        public var item: Project
+
+        @EnvironmentObject public var nav: Navigation
+
+        var body: some View {
+            VStack(alignment: .leading, spacing: 10) {
+                HStack(alignment: .top, spacing: 10) {
+                    Image(systemName: "questionmark.square.fill").symbolRenderingMode(.hierarchical)
+                    Text("Type: Project")
                     Spacer()
+                }
+                .help("Type: Project entity")
+                Divider()
+
+                if let date = item.created {
+                    HStack(alignment: .top, spacing: 10) {
+                        Image(systemName: "calendar.badge.plus").symbolRenderingMode(.hierarchical)
+                        Text(date.description)
+                        Spacer()
+                    }
+                    .help("Created: \(date.description)")
+                    Divider()
+                }
+
+                Spacer()
+                if let company = item.company {
                     HStack(alignment: .top, spacing: 10) {
                         FancyButtonv2(
-                            text: "Open company",
+                            text: "Open project",
                             icon: "arrow.right.square.fill",
                             showLabel: true,
                             size: .link,
                             type: .clear,
-                            redirect: AnyView(CompanyDashboard(company: item)),
+                            redirect: AnyView(CompanyDashboard(company: company)),
                             pageType: .companies,
                             sidebar: AnyView(DefaultCompanySidebar())
                         )
@@ -351,44 +308,215 @@ extension FindDashboard {
                 }
             }
         }
-        
-        struct InspectingPerson: View {
-            public var item: Person
-            
-            @EnvironmentObject public var nav: Navigation
-            
-            var body: some View {
-                VStack(alignment: .leading, spacing: 10) {
+    }
+
+    struct InspectingCompany: View {
+        public var item: Company
+
+        @EnvironmentObject public var nav: Navigation
+
+        var body: some View {
+            VStack(alignment: .leading, spacing: 10) {
+                HStack(alignment: .top, spacing: 10) {
+                    Image(systemName: "questionmark.square.fill").symbolRenderingMode(.hierarchical)
+                    Text("Type: Company")
+                    Spacer()
+                }
+                .help("Type: Company entity")
+                Divider()
+
+                if let date = item.createdDate {
                     HStack(alignment: .top, spacing: 10) {
-                        Image(systemName: "questionmark.square.fill").symbolRenderingMode(.hierarchical)
-                        Text("Type: Person")
+                        Image(systemName: "calendar.badge.plus").symbolRenderingMode(.hierarchical)
+                        Text(date.description)
                         Spacer()
                     }
-                    .help("Type: Person entity")
+                    .help("Created: \(date.description)")
                     Divider()
-                    
-                    if let date = item.created {
-                        HStack(alignment: .top, spacing: 10) {
-                            Image(systemName: "calendar.badge.plus").symbolRenderingMode(.hierarchical)
-                            Text(date.description)
-                            Spacer()
-                        }
-                        .help("Created: \(date.description)")
-                        Divider()
-                    }
-                    
-                    if let date = item.lastUpdate {
-                        HStack(alignment: .top, spacing: 10) {
-                            Image(systemName: "calendar.badge.clock").symbolRenderingMode(.hierarchical)
-                            Text(date.description)
-                            Spacer()
-                        }
-                        .help("Last update: \(date.description)")
-                        Divider()
-                    }
-                    
+                }
+
+                Spacer()
+                HStack(alignment: .top, spacing: 10) {
+                    FancyButtonv2(
+                        text: "Open company",
+                        icon: "arrow.right.square.fill",
+                        showLabel: true,
+                        size: .link,
+                        type: .clear,
+                        redirect: AnyView(CompanyDashboard(company: item)),
+                        pageType: .companies,
+                        sidebar: AnyView(DefaultCompanySidebar())
+                    )
+                }
+            }
+        }
+    }
+
+    struct InspectingPerson: View {
+        public var item: Person
+
+        @EnvironmentObject public var nav: Navigation
+
+        var body: some View {
+            VStack(alignment: .leading, spacing: 10) {
+                HStack(alignment: .top, spacing: 10) {
+                    Image(systemName: "questionmark.square.fill").symbolRenderingMode(.hierarchical)
+                    Text("Type: Person")
                     Spacer()
-                    if let company = item.company {
+                }
+                .help("Type: Person entity")
+                Divider()
+
+                if let date = item.created {
+                    HStack(alignment: .top, spacing: 10) {
+                        Image(systemName: "calendar.badge.plus").symbolRenderingMode(.hierarchical)
+                        Text(date.description)
+                        Spacer()
+                    }
+                    .help("Created: \(date.description)")
+                    Divider()
+                }
+
+                if let date = item.lastUpdate {
+                    HStack(alignment: .top, spacing: 10) {
+                        Image(systemName: "calendar.badge.clock").symbolRenderingMode(.hierarchical)
+                        Text(date.description)
+                        Spacer()
+                    }
+                    .help("Last update: \(date.description)")
+                    Divider()
+                }
+
+                Spacer()
+                if let company = item.company {
+                    HStack(alignment: .top, spacing: 10) {
+                        FancyButtonv2(
+                            text: "Open",
+                            icon: "arrow.right.square.fill",
+                            showLabel: true,
+                            size: .link,
+                            type: .clear,
+                            redirect: AnyView(CompanyDashboard(company: company)),
+                            pageType: .companies,
+                            sidebar: AnyView(DefaultCompanySidebar())
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    struct InspectingNote: View {
+        public var item: Note
+
+        @EnvironmentObject public var nav: Navigation
+
+        var body: some View {
+            VStack(alignment: .leading, spacing: 10) {
+                HStack(alignment: .top, spacing: 10) {
+                    Image(systemName: "questionmark.square.fill").symbolRenderingMode(.hierarchical)
+                    Text("Type: Note")
+                    Spacer()
+                }
+                .help("Type: Note entity")
+                Divider()
+
+                if let date = item.postedDate {
+                    HStack(alignment: .top, spacing: 10) {
+                        Image(systemName: "calendar.badge.plus").symbolRenderingMode(.hierarchical)
+                        Text(date.description)
+                        Spacer()
+                    }
+                    .help("Created: \(date.description)")
+                    Divider()
+                }
+
+                if let date = item.lastUpdate {
+                    HStack(alignment: .top, spacing: 10) {
+                        Image(systemName: "calendar.badge.clock").symbolRenderingMode(.hierarchical)
+                        Text(date.description)
+                        Spacer()
+                    }
+                    .help("Last update: \(date.description)")
+                    Divider()
+                }
+
+                Spacer()
+                HStack(alignment: .top, spacing: 10) {
+                    FancyButtonv2(
+                        text: "Open",
+                        action: {nav.session.search.cancel() ; nav.setInspector()},
+                        icon: "arrow.right.square.fill",
+                        showLabel: true,
+                        size: .link,
+                        type: .clear,
+                        redirect: AnyView(NoteCreate(note: item)),
+                        pageType: .notes,
+                        sidebar: AnyView(NoteCreateSidebar(note: item))
+                    )
+                }
+            }
+        }
+    }
+
+    struct InspectingTask: View {
+        public var item: LogTask
+
+        @EnvironmentObject public var nav: Navigation
+
+        var body: some View {
+            VStack(alignment: .leading, spacing: 10) {
+                HStack(alignment: .top, spacing: 10) {
+                    Image(systemName: "questionmark.square.fill").symbolRenderingMode(.hierarchical)
+                    Text("Type: Task")
+                    Spacer()
+                }
+                .help("Type: Task entity")
+                Divider()
+
+                if let date = item.created {
+                    HStack(alignment: .top, spacing: 10) {
+                        Image(systemName: "calendar.badge.plus").symbolRenderingMode(.hierarchical)
+                        Text(date.description)
+                        Spacer()
+                    }
+                    .help("Created: \(date.description)")
+                    Divider()
+                }
+
+                if let date = item.lastUpdate {
+                    HStack(alignment: .top, spacing: 10) {
+                        Image(systemName: "calendar.badge.clock").symbolRenderingMode(.hierarchical)
+                        Text(date.description)
+                        Spacer()
+                    }
+                    .help("Last update: \(date.description)")
+                    Divider()
+                }
+
+                if let date = item.completedDate {
+                    HStack(alignment: .top, spacing: 10) {
+                        Image(systemName: "calendar.badge.clock").symbolRenderingMode(.hierarchical)
+                        Text(date.description)
+                        Spacer()
+                    }
+                    .help("Completed on \(date.description)")
+                    Divider()
+                }
+
+                if let date = item.cancelledDate {
+                    HStack(alignment: .top, spacing: 10) {
+                        Image(systemName: "calendar.badge.clock").symbolRenderingMode(.hierarchical)
+                        Text(date.description)
+                        Spacer()
+                    }
+                    .help("Cancelled on \(date.description)")
+                    Divider()
+                }
+
+                Spacer()
+                if let job = item.owner {
+                    if let project = job.project {
                         HStack(alignment: .top, spacing: 10) {
                             FancyButtonv2(
                                 text: "Open",
@@ -396,7 +524,7 @@ extension FindDashboard {
                                 showLabel: true,
                                 size: .link,
                                 type: .clear,
-                                redirect: AnyView(CompanyDashboard(company: company)),
+                                redirect: AnyView(TaskDashboardByProject(project: project)),
                                 pageType: .companies,
                                 sidebar: AnyView(DefaultCompanySidebar())
                             )
@@ -405,134 +533,6 @@ extension FindDashboard {
                 }
             }
         }
-        
-        struct InspectingNote: View {
-            public var item: Note
-            
-            @EnvironmentObject public var nav: Navigation
-            
-            var body: some View {
-                VStack(alignment: .leading, spacing: 10) {
-                    HStack(alignment: .top, spacing: 10) {
-                        Image(systemName: "questionmark.square.fill").symbolRenderingMode(.hierarchical)
-                        Text("Type: Note")
-                        Spacer()
-                    }
-                    .help("Type: Note entity")
-                    Divider()
-                    
-                    if let date = item.postedDate {
-                        HStack(alignment: .top, spacing: 10) {
-                            Image(systemName: "calendar.badge.plus").symbolRenderingMode(.hierarchical)
-                            Text(date.description)
-                            Spacer()
-                        }
-                        .help("Created: \(date.description)")
-                        Divider()
-                    }
-                    
-                    if let date = item.lastUpdate {
-                        HStack(alignment: .top, spacing: 10) {
-                            Image(systemName: "calendar.badge.clock").symbolRenderingMode(.hierarchical)
-                            Text(date.description)
-                            Spacer()
-                        }
-                        .help("Last update: \(date.description)")
-                        Divider()
-                    }
-                    
-                    Spacer()
-                    HStack(alignment: .top, spacing: 10) {
-                        FancyButtonv2(
-                            text: "Open",
-                            action: {nav.session.search.cancel()},
-                            icon: "arrow.right.square.fill",
-                            showLabel: true,
-                            size: .link,
-                            type: .clear,
-                            redirect: AnyView(NoteCreate(note: item)),
-                            pageType: .notes,
-                            sidebar: AnyView(NoteCreateSidebar(note: item))
-                        )
-                    }
-                }
-            }
-        }
-        
-        struct InspectingTask: View {
-            public var item: LogTask
-            
-            @EnvironmentObject public var nav: Navigation
-            
-            var body: some View {
-                VStack(alignment: .leading, spacing: 10) {
-                    HStack(alignment: .top, spacing: 10) {
-                        Image(systemName: "questionmark.square.fill").symbolRenderingMode(.hierarchical)
-                        Text("Type: Task")
-                        Spacer()
-                    }
-                    .help("Type: Task entity")
-                    Divider()
-                    
-                    if let date = item.created {
-                        HStack(alignment: .top, spacing: 10) {
-                            Image(systemName: "calendar.badge.plus").symbolRenderingMode(.hierarchical)
-                            Text(date.description)
-                            Spacer()
-                        }
-                        .help("Created: \(date.description)")
-                        Divider()
-                    }
-                    
-                    if let date = item.lastUpdate {
-                        HStack(alignment: .top, spacing: 10) {
-                            Image(systemName: "calendar.badge.clock").symbolRenderingMode(.hierarchical)
-                            Text(date.description)
-                            Spacer()
-                        }
-                        .help("Last update: \(date.description)")
-                        Divider()
-                    }
-                    
-                    if let date = item.completedDate {
-                        HStack(alignment: .top, spacing: 10) {
-                            Image(systemName: "calendar.badge.clock").symbolRenderingMode(.hierarchical)
-                            Text(date.description)
-                            Spacer()
-                        }
-                        .help("Completed on \(date.description)")
-                        Divider()
-                    }
-                    
-                    if let date = item.cancelledDate {
-                        HStack(alignment: .top, spacing: 10) {
-                            Image(systemName: "calendar.badge.clock").symbolRenderingMode(.hierarchical)
-                            Text(date.description)
-                            Spacer()
-                        }
-                        .help("Cancelled on \(date.description)")
-                        Divider()
-                    }
-                    
-                    Spacer()
-                    if let job = item.owner {
-                        if let project = job.project {
-                            HStack(alignment: .top, spacing: 10) {
-                                FancyButtonv2(
-                                    text: "Open",
-                                    icon: "arrow.right.square.fill",
-                                    showLabel: true,
-                                    size: .link,
-                                    type: .clear,
-                                    redirect: AnyView(TaskDashboardByProject(project: project)),
-                                    pageType: .companies,
-                                    sidebar: AnyView(DefaultCompanySidebar())
-                                )
-                            }
-                        }
-                    }
-                }
-            }
-        }
     }
 }
+

--- a/DLPrototype/Views/Find/Suggestions/Suggestions.swift
+++ b/DLPrototype/Views/Find/Suggestions/Suggestions.swift
@@ -21,12 +21,14 @@ extension FindDashboard {
         @Binding public var showPeople: Bool
         public var location: WidgetLocation
 
+        @AppStorage("CreateEntitiesWidget.isSearching") private var isSearching: Bool = false
+
         @Environment(\.managedObjectContext) var moc
         @EnvironmentObject public var nav: Navigation
 
         var body: some View {
             VStack {
-                if searchText.count >= 2 {
+                if searchText.count >= 2 || isSearching {
                     ScrollView(showsIndicators: false) {
                         VStack {
                             HStack {

--- a/DLPrototype/Views/Shared/AppSidebar/SidebarItem.swift
+++ b/DLPrototype/Views/Shared/AppSidebar/SidebarItem.swift
@@ -79,9 +79,13 @@ struct SidebarItem: View, Identifiable {
     public var showBorder: Bool = true
     public var showButton: Bool = true
 
+    @AppStorage("CreateEntitiesWidget.isSearchStackShowing") private var isSearching: Bool = false
+
     @State private var highlighted: Bool = false
     @State private var altIcon: String?
-    
+
+    @EnvironmentObject public var nav: Navigation
+
     var body: some View {
         HStack(alignment: .top, spacing: 0) {
             if orientation == .left {
@@ -98,6 +102,13 @@ struct SidebarItem: View, Identifiable {
             Button("Copy \(data)") {
                 ClipboardHelper.copy(data)
             }
+            Divider()
+            Button(action: {
+                isSearching = true
+                nav.session.search.text = data
+            }, label: {
+                Text("Inspect")
+            })
         }
     }
 

--- a/DLPrototype/Views/Shared/AppSidebar/Widgets/CreateEntitiesWidget.swift
+++ b/DLPrototype/Views/Shared/AppSidebar/Widgets/CreateEntitiesWidget.swift
@@ -172,6 +172,7 @@ struct CreateEntitiesWidget: View {
 
     struct FindButton: View {
         @AppStorage("CreateEntitiesWidget.isCreateStackShowing") private var isCreateStackShowing: Bool = false
+        @AppStorage("CreateEntitiesWidget.isSearching") private var isSearching: Bool = false
 
         @Binding public var active: Bool
         
@@ -184,7 +185,7 @@ struct CreateEntitiesWidget: View {
                         Theme.base.opacity(0.5)
                         FancyButtonv2(
                             text: "Search",
-                            action: {active.toggle() ; isCreateStackShowing = false ; nav.session.search.cancel()},
+                            action: {active.toggle() ; isSearching.toggle() ; isCreateStackShowing = false ; nav.session.search.cancel()},
                             icon: "magnifyingglass",
                             showLabel: false,
                             size: .small,

--- a/DLPrototype/Views/Shared/PanelGroup/Panel.swift
+++ b/DLPrototype/Views/Shared/PanelGroup/Panel.swift
@@ -97,7 +97,7 @@ extension Panel.Row {
 struct CompanyPanel: View {
     public var position: Panel.Position
 
-    @AppStorage("CreateEntitiesWidget.isSearching") private var isSearching: Bool = false
+    @AppStorage("CreateEntitiesWidget.isSearchStackShowing") private var isSearching: Bool = false
 
     @State private var showSearch: Bool = false
     @State private var searchText: String = ""
@@ -151,12 +151,12 @@ struct CompanyPanel: View {
                                         )
                                         .contextMenu {
                                             Button(action: {
-                                                isSearching.toggle() // doesn't work :(((
+                                                isSearching = true
+                                                nav.setInspector(AnyView(Inspector(entity: company)))
+
                                                 if let name = company.name {
                                                     nav.session.search.text = name
-                                                };
-
-                                                nav.session.search.inspect(company)
+                                                }
                                             }, label: {
                                                 Text("Inspect")
                                             })
@@ -261,7 +261,9 @@ extension CompanyPanel {
 
 struct ProjectPanel: View {
     public var position: Panel.Position
-    
+
+    @AppStorage("CreateEntitiesWidget.isSearchStackShowing") private var isSearching: Bool = false
+
     @State private var showSearch: Bool = false
     @State private var searchText: String = ""
 
@@ -313,6 +315,18 @@ struct ProjectPanel: View {
                                             position: position
                                         )
                                     )
+                                    .contextMenu {
+                                        Button(action: {
+                                            isSearching = true
+                                            nav.setInspector(AnyView(Inspector(entity: project)))
+
+                                            if let name = project.name {
+                                                nav.session.search.text = name
+                                            }
+                                        }, label: {
+                                            Text("Inspect")
+                                        })
+                                    }
                                 }
                             }
                         }
@@ -368,7 +382,9 @@ extension ProjectPanel {
 
 public struct JobPanel: View {
     public var position: Panel.Position
-    
+
+    @AppStorage("CreateEntitiesWidget.isSearchStackShowing") private var isSearching: Bool = false
+
     @State private var showSearch: Bool = false
     @State private var searchText: String = ""
 
@@ -421,6 +437,15 @@ public struct JobPanel: View {
                                             position: position
                                         )
                                     )
+                                    .contextMenu {
+                                        Button(action: {
+                                            isSearching = true
+                                            nav.setInspector(AnyView(Inspector(entity: job)))
+                                            nav.session.search.text = job.jid.string
+                                        }, label: {
+                                            Text("Inspect")
+                                        })
+                                    }
                                 }
                             }
                         }
@@ -458,6 +483,8 @@ extension JobPanel {
 
 public struct NotePanel: View {
     public var position: Panel.Position
+
+    @AppStorage("CreateEntitiesWidget.isSearchStackShowing") private var isSearching: Bool = false
 
     @State private var showSearch: Bool = false
     @State private var searchText: String = ""
@@ -516,6 +543,18 @@ public struct NotePanel: View {
                                             position: position
                                         )
                                     )
+                                    .contextMenu {
+                                        Button(action: {
+                                            isSearching = true
+                                            nav.setInspector(AnyView(Inspector(entity: note)))
+
+                                            if let name = note.title {
+                                                nav.session.search.text = name
+                                            }
+                                        }, label: {
+                                            Text("Inspect")
+                                        })
+                                    }
                                 }
                             }
                         }

--- a/DLPrototype/Views/Shared/PanelGroup/Panel.swift
+++ b/DLPrototype/Views/Shared/PanelGroup/Panel.swift
@@ -96,7 +96,9 @@ extension Panel.Row {
 
 struct CompanyPanel: View {
     public var position: Panel.Position
-    
+
+    @AppStorage("CreateEntitiesWidget.isSearching") private var isSearching: Bool = false
+
     @State private var showSearch: Bool = false
     @State private var searchText: String = ""
 
@@ -147,6 +149,18 @@ struct CompanyPanel: View {
                                                 specialIcon: "building.2"
                                             )
                                         )
+                                        .contextMenu {
+                                            Button(action: {
+                                                isSearching.toggle() // doesn't work :(((
+                                                if let name = company.name {
+                                                    nav.session.search.text = name
+                                                };
+
+                                                nav.session.search.inspect(company)
+                                            }, label: {
+                                                Text("Inspect")
+                                            })
+                                        }
                                     }
                                 }
                             }

--- a/DLPrototype/Views/Shared/SessionInspector.swift
+++ b/DLPrototype/Views/Shared/SessionInspector.swift
@@ -11,7 +11,7 @@ import SwiftUI
 struct SessionInspector: View {
     @EnvironmentObject private var nav: Navigation
     
-    @State private var form: Navigation.Forms.JobSelectorForm? = nil
+    @State private var form: Navigation.Forms.ThreePanelForm? = nil
 
     var body: some View {
         VStack(alignment: .leading) {
@@ -24,8 +24,8 @@ struct SessionInspector: View {
             }
         }
         .padding()
-        .onChange(of: nav.forms.jobSelector.selected) { _ in
-            form = nav.forms.jobSelector
+        .onChange(of: nav.forms.tp.selected) { _ in
+            form = nav.forms.tp
         }
         .frame(width: 500)
     }


### PR DESCRIPTION
Project notebooks are just your notes grouped together by project instead of by job. There is a new interface for browsing through them on Notes.

You can inspect objects using the context menu "Inspect" item, now. I'm sure I missed a few, but you should be able to right click most entities, choose Inspect, then see the inspector panel open and the search panel populated with a search query.

Closes #215