### PR TITLE
Open some suggestions automatically + Calendar selection bugfix

### DIFF
--- a/DLPrototype/Models/CoreData/CoreDataCalendarEvent.swift
+++ b/DLPrototype/Models/CoreData/CoreDataCalendarEvent.swift
@@ -212,7 +212,7 @@ public class CoreDataCalendarEvent: ObservableObject {
     }
 
     public func getCalendars() -> [EKCalendar] {
-        return store.calendars(for: .event)
+        return store.calendars(for: .event).sorted(by: {$0.title <= $1.title})
     }
 
     public func getCalendarsForPicker() -> [CustomPickerItem] {

--- a/DLPrototype/Views/Find/Suggestions/Suggestions.swift
+++ b/DLPrototype/Views/Find/Suggestions/Suggestions.swift
@@ -54,6 +54,10 @@ extension FindDashboard {
                 }
             }
             .background(location == .content ? Theme.rowColour : Color.clear)
+            .onChange(of: isSearching) { status in
+                nav.session.search.cancel()
+                nav.setInspector()
+            }
         }
         
         struct SuggestedJobs: View {


### PR DESCRIPTION
* Suggestions with fewer than 6 children will open automatically while searching.
* Selecting a calendar now shows the correct events ALL the time.