### PR TITLE
New experimental feature: CLI mode

### DIFF
--- a/DLPrototype.xcodeproj/project.pbxproj
+++ b/DLPrototype.xcodeproj/project.pbxproj
@@ -60,6 +60,7 @@
 		533E40652970DA640007785A /* ViewUpdater.swift in Sources */ = {isa = PBXBuildFile; fileRef = 533E40642970DA640007785A /* ViewUpdater.swift */; };
 		533E40682970DD170007785A /* AutoFixJobs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 533E40672970DD170007785A /* AutoFixJobs.swift */; };
 		533E406A2970F5610007785A /* SearchHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 533E40692970F5610007785A /* SearchHelper.swift */; };
+		53450CEC2BF46ECF007F45FB /* CommandLineInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53450CEB2BF46ECF007F45FB /* CommandLineInterface.swift */; };
 		5345C9CD2B31315F004A4188 /* SearchLanguage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5345C9CC2B31315F004A4188 /* SearchLanguage.swift */; };
 		534B7C2B2B3220E40017C155 /* DispatchQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 534B7C2A2B3220E40017C155 /* DispatchQueue.swift */; };
 		53521E54296FBDAE002E7F21 /* CoreDataNoteVersions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53521E53296FBDAE002E7F21 /* CoreDataNoteVersions.swift */; };
@@ -298,6 +299,7 @@
 		533E40642970DA640007785A /* ViewUpdater.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewUpdater.swift; sourceTree = "<group>"; };
 		533E40672970DD170007785A /* AutoFixJobs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoFixJobs.swift; sourceTree = "<group>"; };
 		533E40692970F5610007785A /* SearchHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchHelper.swift; sourceTree = "<group>"; };
+		53450CEB2BF46ECF007F45FB /* CommandLineInterface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandLineInterface.swift; sourceTree = "<group>"; };
 		5345C9CC2B31315F004A4188 /* SearchLanguage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchLanguage.swift; sourceTree = "<group>"; };
 		534B7C2A2B3220E40017C155 /* DispatchQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DispatchQueue.swift; sourceTree = "<group>"; };
 		53521E53296FBDAE002E7F21 /* CoreDataNoteVersions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreDataNoteVersions.swift; sourceTree = "<group>"; };
@@ -494,8 +496,10 @@
 				53EFCE7729637EA0004E45EC /* LogTable */,
 				537368D024B93DB600193E88 /* Today.swift */,
 				53C000992B3A90DF00D5EC04 /* PostingInterface.swift */,
+				53450CEB2BF46ECF007F45FB /* CommandLineInterface.swift */,
 			);
-			path = Today;
+			name = Today;
+			path = Entities/Today;
 			sourceTree = "<group>";
 		};
 		53152CE0296BC75A00A14E43 /* Settings */ = {
@@ -773,6 +777,7 @@
 		537368D224B93DF700193E88 /* Views */ = {
 			isa = PBXGroup;
 			children = (
+				53152CDF296BC74900A14E43 /* Today */,
 				53BDA6942B41BC2800A61BE8 /* Entities */,
 				53D5E2962A85A75000FE293A /* Planning */,
 				535C1ADF29F48EE600CD95FD /* Dashboard */,
@@ -952,7 +957,6 @@
 				53C3418A299960080071B855 /* Jobs */,
 				5335A5AF296D164F000051B1 /* Tasks */,
 				537628AD29665B7B00DE8ECF /* Notes */,
-				53152CDF296BC74900A14E43 /* Today */,
 				5363B6762A6BB2B300C2FBB8 /* Companies */,
 				53B0BE7D29725413007CB663 /* Projects */,
 			);
@@ -1306,6 +1310,7 @@
 				535C1AEE29F49AAD00CD95FD /* StatsWidget.swift in Sources */,
 				53959A1F29738AAA007A2549 /* FancySubTitle.swift in Sources */,
 				5372C02A2A105AA1008CB120 /* FancyChip.swift in Sources */,
+				53450CEC2BF46ECF007F45FB /* CommandLineInterface.swift in Sources */,
 				537628B429665F4E00DE8ECF /* Data.xcdatamodeld in Sources */,
 				53F5896429983FA300843B32 /* ProjectResult.swift in Sources */,
 				53842B272B4C82B20029AC73 /* Project.swift in Sources */,

--- a/DLPrototype/Utils/Navigation.swift
+++ b/DLPrototype/Utils/Navigation.swift
@@ -208,9 +208,11 @@ extension Navigation {
     }
     
     public struct CommandLineSession {
+        typealias CLIAppType = CommandLineInterface.App.AppType
+
         var history: [History] = []
         var command: String?
-        var app: CommandLineInterface.App.AppType = .log
+        var app: CLIAppType = .log
         
         public struct History: Identifiable {
             public var id: UUID = UUID()
@@ -218,6 +220,7 @@ extension Navigation {
             var command: String
             var status: Status = .standard
             var message: String
+            var appType: CLIAppType
             
             public enum Status {
                 case success, error, warning, standard

--- a/DLPrototype/Utils/Navigation.swift
+++ b/DLPrototype/Utils/Navigation.swift
@@ -204,6 +204,19 @@ extension Navigation {
         var search: Search = Search(moc: PersistenceController.shared.container.viewContext)
         var toolbar: Toolbar = Toolbar()
         var eventStatus: EventIndicatorStatus = .ready
+        var cli: CommandLineSession = CommandLineSession()
+    }
+    
+    public struct CommandLineSession {
+        var history: [History] = []
+        var command: String?
+        var app: CommandLineInterface.App.AppType = .log
+        
+        public struct History: Identifiable {
+            public var id: UUID = UUID()
+            var time: Date = Date()
+            var command: String
+        }
     }
 
     // @TODO: remove from Navigation

--- a/DLPrototype/Utils/Navigation.swift
+++ b/DLPrototype/Utils/Navigation.swift
@@ -216,6 +216,11 @@ extension Navigation {
             public var id: UUID = UUID()
             var time: Date = Date()
             var command: String
+            var status: Status = .standard
+            
+            enum Status {
+                case success, error, warning, standard
+            }
         }
     }
 

--- a/DLPrototype/Utils/Navigation.swift
+++ b/DLPrototype/Utils/Navigation.swift
@@ -217,9 +217,30 @@ extension Navigation {
             var time: Date = Date()
             var command: String
             var status: Status = .standard
+            var message: String
             
-            enum Status {
+            public enum Status {
                 case success, error, warning, standard
+                
+                var icon: Image {
+                    switch self {
+                    case .success, .standard:
+                        Image(systemName: "checkmark.circle.fill")
+                    case .error:
+                        Image(systemName: "xmark.circle.fill")
+                    case .warning:
+                        Image(systemName: "triangle.circle.fill")
+                    }
+                }
+                
+                var colour: Color {
+                    switch self {
+                    case .standard: .white
+                    case .success: .green
+                    case .error: .red
+                    case .warning: .yellow
+                    }
+                }
             }
         }
     }

--- a/DLPrototype/Views/Entities/Today/CommandLineInterface.swift
+++ b/DLPrototype/Views/Entities/Today/CommandLineInterface.swift
@@ -9,7 +9,14 @@
 import SwiftUI
 
 struct CommandLineInterface: View {
+    typealias CLIApp = CommandLineInterface.App
+    typealias Status = Navigation.CommandLineSession.History.Status
+
     static private let maxItems: Int = 500
+    
+    @State private var apps: [CLIApp] = []
+    @State private var selected: CLIApp.AppType = .log
+    @State public var command: String = ""
     
     @AppStorage("today.commandLineMode") private var commandLineMode: Bool = false
     
@@ -18,95 +25,14 @@ struct CommandLineInterface: View {
     var body: some View {
         VStack(alignment: .leading) {
             Display()
-            Prompt()
-        }
-        .background(Theme.textBackground)
-    }
-}
-
-#Preview {
-    CommandLineInterface()
-}
-
-extension CommandLineInterface {
-    struct App {
-        var id: UUID = UUID()
-        var type: AppType
-        var action: () -> Void
-        var promptPlaceholder: String
-        
-        enum AppType: CaseIterable {
-            case log, query
             
-            var fgColour: Color {
-                .white
-            }
-            
-            var bgColour: Color {
-                switch self {
-                case .log: .blue
-                case .query: .red
-                }
-            }
-            
-            var name: String {
-                switch self {
-                case .log: "log"
-                case .query: "query"
-                }
-            }
-        }
-    }
-    
-    struct Display: View {
-        @EnvironmentObject public var nav: Navigation
-        
-        var body: some View {
-            VStack(alignment: .leading, spacing: 1) {
-                Spacer()
-                ScrollView {
-                    ForEach(nav.session.cli.history) { line in
-                        HStack {
-                            Text("[\(line.time.formatted(date: .abbreviated, time: .complete))]")
-                                .foregroundStyle(.gray)
-                            Text(line.command)
-                            Spacer()
-                        }
+            // Prompt
+            ZStack {
+                ForEach(apps) { app in
+                    if app.type == selected {
+                        app
                     }
                 }
-            }
-            .padding([.leading, .trailing, .bottom])
-            .font(Theme.fontTextField)
-        }
-    }
-    
-    struct Prompt: View {
-        @State public var command: String = ""
-        
-        @AppStorage("today.commandLineMode") private var commandLineMode: Bool = false
-        
-        @FocusState private var primaryTextFieldInFocus: Bool
-        
-        @EnvironmentObject public var nav: Navigation
-        
-        var body: some View {
-            ZStack {
-                HStack(spacing: 0) {
-                    Text("$")
-                        .padding([.leading, .top, .bottom])
-                        .background(Theme.textBackground)
-                        .font(.title2)
-
-                    AppSelector()
-
-                    FancyTextField(
-                        placeholder: "What are you working on?",
-                        onSubmit: execute,
-                        font: .title2,
-                        text: $command
-                    )
-                }
-                
                 HStack {
                     Spacer()
                     FancyButtonv2(
@@ -124,42 +50,167 @@ extension CommandLineInterface {
                 .padding(.trailing)
             }
         }
+        .background(Theme.textBackground)
+        .onAppear(perform: actionOnAppear)
     }
 }
 
-extension CommandLineInterface.Prompt {
-    struct AppSelector: View {
-        typealias CLIApp = CommandLineInterface.App
+extension CommandLineInterface {
+    private func executeLogAction() -> Void {
+        self.updateDisplay(
+            status: nav.session.job == nil ? .error : .standard,
+            message: nav.session.job == nil ? "You must select a job first" : ""
+        )
         
-        private var apps: [CLIApp] = [
-            CLIApp(type: .log, action: {}, promptPlaceholder: "What are you working on?"),
-            CLIApp(type: .query, action: {}, promptPlaceholder: "Find stuff"),
+        self.clear()
+    }
+    
+    private func executeQueryAction() -> Void {
+        self.updateDisplay(status: .standard, message: "Searching for X")
+        self.clear()
+        
+    }
+    
+    private func executeSetAction() -> Void {
+        self.updateDisplay(status: .standard, message: "Set X = Y")
+        self.clear()
+    }
+    
+    private func actionOnAppear() -> Void {
+        self.apps = [
+            CLIApp(type: .log, action: self.executeLogAction, promptPlaceholder: "What are you working on?", command: $command),
+            CLIApp(type: .query, action: self.executeQueryAction, promptPlaceholder: "Find stuff", command: $command),
+            CLIApp(type: .set, action: self.executeSetAction, promptPlaceholder: "Configure things", command: $command)
         ]
-        
-        @State private var selected: CLIApp.AppType = .log
-
-        var body: some View {
-            Text("log")
-                .padding([.top, .bottom, .leading])
-                .background(Theme.textBackground)
-                .font(.title2)
+    }
+    
+    private func clear() -> Void {
+        nav.session.cli.command = nil
+        command = ""
+    }
+    
+    private func updateDisplay(status: Status, message: String) -> Void {
+        if nav.session.cli.history.count <= CommandLineInterface.maxItems {
+            nav.session.cli.history.append(
+                Navigation.CommandLineSession.History(
+                    command: command,
+                    status: nav.session.job == nil ? .error : .standard,
+                    message: nav.session.job == nil ? "You must select a job first" : ""
+                )
+            )
         }
     }
 }
 
-extension CommandLineInterface.Prompt {
-    private func execute() -> Void {
-        if nav.session.cli.history.count <= CommandLineInterface.maxItems {
-            if nav.session.job == nil {
-                command = "ERROR: select a job first"
+#Preview {
+    CommandLineInterface()
+}
+
+extension CommandLineInterface {
+    struct App: View, Identifiable {
+        var id: UUID = UUID()
+        var type: AppType
+        var action: () -> Void
+        var promptPlaceholder: String
+        
+        @Binding public var command: String
+        
+        var body: some View {
+            HStack(spacing: 0) {
+                Text("$")
+                    .padding([.leading, .top, .bottom])
+                    .background(Theme.textBackground)
+                    .font(.title2)
+                
+                CommandLineInterface.AppSelector(selected: type)
+                
+                FancyTextField(
+                    placeholder: promptPlaceholder,
+                    onSubmit: action,
+                    font: .title2,
+                    text: $command
+                )
+            }
+        }
+        
+        enum AppType: CaseIterable, Identifiable {
+            case log, query, set
+            
+            var id: UUID {
+                UUID()
             }
             
-            nav.session.cli.history.append(
-                Navigation.CommandLineSession.History(command: command)
-            )
+            var fgColour: Color {
+                .white
+            }
             
-            nav.session.cli.command = nil
-            command = ""
+            var bgColour: Color {
+                switch self {
+                case .log: .blue
+                case .query: .red
+                case .set: .orange
+                }
+            }
+            
+            var name: String {
+                switch self {
+                case .log: "log"
+                case .query: "query"
+                case .set: "set"
+                }
+            }
+        }
+    }
+    
+    struct Display: View {
+        @EnvironmentObject public var nav: Navigation
+        
+        var body: some View {
+            VStack(alignment: .leading, spacing: 1) {
+                Spacer()
+                ScrollView {
+                    VStack(spacing: 1) {
+                        ForEach(nav.session.cli.history) { line in
+                            VStack(alignment: .leading, spacing: 1) {
+                                HStack {
+                                    line.status.icon
+                                        .foregroundStyle(line.status.colour)
+                                    
+                                    Text("[\(line.time.formatted(date: .abbreviated, time: .complete))]")
+                                        .foregroundStyle(.gray)
+                                    Text(line.command)
+                                    Spacer()
+                                }
+                                
+                                if [.error, .warning].contains(line.status) {
+                                    HStack {
+                                        Image(systemName: "arrow.turn.down.right")
+                                            .padding([.leading], 8)
+                                        Text(line.message)
+                                    }
+                                    .foregroundStyle(line.status.colour)
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            .padding([.leading, .trailing, .bottom])
+            .font(Theme.fontTextField)
+        }
+    }
+    
+    struct AppSelector: View {
+        typealias CLIApp = CommandLineInterface.App
+        
+        public var selected: CLIApp.AppType
+
+        var body: some View {
+            Text(selected.name)
+                .padding([.top, .bottom, .leading])
+                .background(Theme.textBackground)
+                .font(.title2)
+        
         }
     }
 }

--- a/DLPrototype/Views/Entities/Today/CommandLineInterface.swift
+++ b/DLPrototype/Views/Entities/Today/CommandLineInterface.swift
@@ -1,0 +1,165 @@
+//
+//  CommandLineInterface.swift
+//  DLPrototype
+//
+//  Created by Ryan Priebe on 2024-05-14.
+//  Copyright © 2024 YegCollective. All rights reserved.
+//
+
+import SwiftUI
+
+struct CommandLineInterface: View {
+    static private let maxItems: Int = 500
+    
+    @AppStorage("today.commandLineMode") private var commandLineMode: Bool = false
+    
+    @EnvironmentObject public var nav: Navigation
+
+    var body: some View {
+        VStack(alignment: .leading) {
+            Display()
+            Prompt()
+        }
+        .background(Theme.textBackground)
+    }
+}
+
+#Preview {
+    CommandLineInterface()
+}
+
+extension CommandLineInterface {
+    struct App {
+        var id: UUID = UUID()
+        var type: AppType
+        var action: () -> Void
+        var promptPlaceholder: String
+        
+        enum AppType: CaseIterable {
+            case log, query
+            
+            var fgColour: Color {
+                .white
+            }
+            
+            var bgColour: Color {
+                switch self {
+                case .log: .blue
+                case .query: .red
+                }
+            }
+            
+            var name: String {
+                switch self {
+                case .log: "log"
+                case .query: "query"
+                }
+            }
+        }
+    }
+    
+    struct Display: View {
+        @EnvironmentObject public var nav: Navigation
+        
+        var body: some View {
+            VStack(alignment: .leading, spacing: 1) {
+                Spacer()
+                ScrollView {
+                    ForEach(nav.session.cli.history) { line in
+                        HStack {
+                            Text("[\(line.time.formatted(date: .abbreviated, time: .complete))]")
+                                .foregroundStyle(.gray)
+                            Text(line.command)
+                            Spacer()
+                        }
+                    }
+                }
+            }
+            .padding([.leading, .trailing, .bottom])
+            .font(Theme.fontTextField)
+        }
+    }
+    
+    struct Prompt: View {
+        @State public var command: String = ""
+        
+        @AppStorage("today.commandLineMode") private var commandLineMode: Bool = false
+        
+        @FocusState private var primaryTextFieldInFocus: Bool
+        
+        @EnvironmentObject public var nav: Navigation
+        
+        var body: some View {
+            ZStack {
+                HStack(spacing: 0) {
+                    Text("$")
+                        .padding([.leading, .top, .bottom])
+                        .background(Theme.textBackground)
+                        .font(.title2)
+
+                    AppSelector()
+
+                    FancyTextField(
+                        placeholder: "What are you working on?",
+                        onSubmit: execute,
+                        font: .title2,
+                        text: $command
+                    )
+                }
+                
+                HStack {
+                    Spacer()
+                    FancyButtonv2(
+                        text: "Exit CLI mode",
+                        action: {commandLineMode.toggle()},
+                        icon: "apple.terminal",
+                        fgColour: .white,
+                        showLabel: false,
+                        size: .tiny,
+                        type: .clear
+                    )
+                    .help("Exit CLI mode")
+                    .frame(width: 30, height: 30)
+                }
+                .padding(.trailing)
+            }
+        }
+    }
+}
+
+extension CommandLineInterface.Prompt {
+    struct AppSelector: View {
+        typealias CLIApp = CommandLineInterface.App
+        
+        private var apps: [CLIApp] = [
+            CLIApp(type: .log, action: {}, promptPlaceholder: "What are you working on?"),
+            CLIApp(type: .query, action: {}, promptPlaceholder: "Find stuff"),
+        ]
+        
+        @State private var selected: CLIApp.AppType = .log
+
+        var body: some View {
+            Text("log")
+                .padding([.top, .bottom, .leading])
+                .background(Theme.textBackground)
+                .font(.title2)
+        }
+    }
+}
+
+extension CommandLineInterface.Prompt {
+    private func execute() -> Void {
+        if nav.session.cli.history.count <= CommandLineInterface.maxItems {
+            if nav.session.job == nil {
+                command = "ERROR: select a job first"
+            }
+            
+            nav.session.cli.history.append(
+                Navigation.CommandLineSession.History(command: command)
+            )
+            
+            nav.session.cli.command = nil
+            command = ""
+        }
+    }
+}

--- a/DLPrototype/Views/Entities/Today/CommandLineInterface.swift
+++ b/DLPrototype/Views/Entities/Today/CommandLineInterface.swift
@@ -99,7 +99,6 @@ extension CommandLineInterface {
     private func executeQueryAction() -> Void {
         self.updateDisplay(status: .standard, message: "Searching for X")
         self.clear()
-        
     }
     
     private func executeSetAction() -> Void {

--- a/DLPrototype/Views/Entities/Today/PostingInterface.swift
+++ b/DLPrototype/Views/Entities/Today/PostingInterface.swift
@@ -11,9 +11,10 @@ import SwiftUI
 extension Today {
     struct PostingInterface: View {
         @State private var text: String = ""
-        
         @State private var errorNoJob: Bool = false
         @State private var errorNoContent: Bool = false
+        @AppStorage("today.commandLineMode") private var commandLineMode: Bool = false
+        @AppStorage("general.experimental.cli") private var allowCLIMode: Bool = false
 
         @FocusState private var primaryTextFieldInFocus: Bool
 
@@ -49,6 +50,23 @@ extension Today {
                         Spacer()
                         HStack(spacing: 5) {
                             Spacer()
+
+                            if allowCLIMode {
+                                FancyButtonv2(
+                                    text: "Command line mode",
+                                    action: {commandLineMode.toggle()},
+                                    icon: "apple.terminal",
+                                    fgColour: .white,
+                                    showLabel: false,
+                                    size: .tiny,
+                                    type: .clear
+                                )
+                                .help("Enter CLI mode")
+                                .frame(width: 30, height: 30)
+                                .background(nav.session.job != nil ? nav.session.job!.colour_from_stored() : Theme.toolbarColour)
+                                .disabled(false)
+                            }
+
                             FancyButtonv2(
                                 text: "Reset interface to default state",
                                 action: clearAction,

--- a/DLPrototype/Views/Entities/Today/Today.swift
+++ b/DLPrototype/Views/Entities/Today/Today.swift
@@ -9,16 +9,23 @@ import SwiftUI
 
 struct Today: View {
     public var defaultSelectedDate: Date? = nil
+    
+    @AppStorage("today.commandLineMode") private var commandLineMode: Bool = false
 
-    @Environment(\.managedObjectContext) var moc
     @EnvironmentObject public var nav: Navigation
 
     var body: some View {
         VStack(alignment: .leading) {
-            PostingInterface()
-            LogTable()
+            if commandLineMode {
+                CommandLineInterface()
+            } else {
+                VStack(alignment: .leading) {
+                    PostingInterface()
+                    LogTable()
+                }
+                .padding()
+            }
         }
-        .padding()
         .background(Theme.toolbarColour)
     }
 }

--- a/DLPrototype/Views/Settings/Tabs/GeneralSettings.swift
+++ b/DLPrototype/Views/Settings/Tabs/GeneralSettings.swift
@@ -12,6 +12,7 @@ import CoreSpotlight
 struct GeneralSettings: View {
     @AppStorage("tigerStriped") private var tigerStriped: Bool = false
     @AppStorage("showExperimentalFeatures") private var showExperimentalFeatures: Bool = false
+    @AppStorage("general.experimental.cli") private var cliMode: Bool = false
     @AppStorage("enableAutoCorrection") public var enableAutoCorrection: Bool = false
     @AppStorage("dashboard.maxYearsPastInHistory") public var maxYearsPastInHistory: Int = 5
     @AppStorage("general.syncColumns") public var syncColumns: Bool = false
@@ -33,6 +34,7 @@ struct GeneralSettings: View {
                 if showExperimentalFeatures {
                     Toggle("Enable SessionInspector panel", isOn: $showSessionInspector)
                     Toggle("Spotlight (data is NOT shared with Apple)", isOn: $spotlightIndex)
+                    Toggle("Enable CLI mode", isOn: $cliMode)
                 }
             }
 

--- a/DLPrototype/Views/Shared/AppSidebar/SidebarButton.swift
+++ b/DLPrototype/Views/Shared/AppSidebar/SidebarButton.swift
@@ -76,7 +76,7 @@ struct SidebarButton: View, Identifiable {
             nav.to(pageType)
         }, label: {
             ZStack {
-                backgroundColour
+                highlighted ? backgroundColour.opacity(0.9) : backgroundColour.opacity(1)
 
                 if nav.parent != pageType {
                     HStack {

--- a/DLPrototype/Views/Shared/Fancy/FancyTextField.swift
+++ b/DLPrototype/Views/Shared/Fancy/FancyTextField.swift
@@ -52,7 +52,7 @@ struct FancyTextField: View {
     
     private var oneLine: some View {
         TextField(placeholder, text: $text)
-            .font(Theme.fontTextField)
+            .font(font)
             .textFieldStyle(.plain)
             .disableAutocorrection(!enableAutoCorrection)
             .padding()
@@ -69,7 +69,7 @@ struct FancyTextField: View {
     
     private var oneBigLine: some View {
         TextField(placeholder, text: $text, axis: .vertical)
-            .font(Theme.fontTextField)
+            .font(font)
             .textFieldStyle(.plain)
             .disableAutocorrection(!enableAutoCorrection)
             .padding()


### PR DESCRIPTION
1. Check "Experimental features" in general settings.
2. Check "Enable CLI mode".
3. Visit Today and click the "Enter CLI mode" button (below).
4. You're now in CLI mode, which runs the "log" command by default. "Query" and "set" commands are coming soon, allowing you to find information and change various app/data settings, respectively.
5. FOR THIS RELEASE you can ONLY log items, as you would using the standard field/table display. It is simply an alternative view.

<img width="134" alt="Screenshot 2024-05-15 at 1 57 16 PM" src="https://github.com/aapis/KlockWork/assets/899633/165aafb8-035e-4956-9479-774ae8f2d30b">

<img width="1174" alt="Screenshot 2024-05-15 at 1 55 07 PM" src="https://github.com/aapis/KlockWork/assets/899633/82be2a0d-e440-4513-9c6c-31a78cb5d358">

