### PR TITLE
CLI mode UX improvement, new Set command

### DIFF
--- a/DLPrototype/Parsers/SearchLanguage.swift
+++ b/DLPrototype/Parsers/SearchLanguage.swift
@@ -153,7 +153,7 @@ extension SearchLanguage.Results {
                     }
                 }
             default:
-                print("DERPO unimplemented Species \(component.species.name)")
+                print("[debug] Unimplemented Species \(component.species.name)")
             }
             
             if jobs.count > 0 {

--- a/DLPrototype/Utils/Navigation.swift
+++ b/DLPrototype/Utils/Navigation.swift
@@ -208,11 +208,13 @@ extension Navigation {
     }
     
     public struct CommandLineSession {
+        typealias CLIApp = CommandLineInterface.App
         typealias CLIAppType = CommandLineInterface.App.AppType
 
         var history: [History] = []
         var command: String?
         var app: CLIAppType = .log
+        var selected: CLIApp?
         
         public struct History: Identifiable {
             public var id: UUID = UUID()

--- a/DLPrototype/Views/Entities/Today/CommandLineInterface.swift
+++ b/DLPrototype/Views/Entities/Today/CommandLineInterface.swift
@@ -180,9 +180,9 @@ extension CommandLineInterface {
         @Binding public var showSelectorPanel: Bool
         @Binding public var command: String
         @Binding public var selected: AppType
-        
+
         @EnvironmentObject public var nav: Navigation
-        
+
         var body: some View {
             HStack(spacing: 0) {
                 CommandLineInterface.AppSelectorButton(type: type, showSelectorPanel: $showSelectorPanel, selected: $selected)
@@ -195,6 +195,22 @@ extension CommandLineInterface {
                     text: $command
                 )
                 .disabled(showSelectorPanel)
+            }
+            .onAppear(perform: actionOnAppear)
+        }
+        
+        private func actionOnAppear() -> Void {
+            NSEvent.addLocalMonitorForEvents(matching: .keyDown) {
+                let code = Int($0.keyCode)
+                
+                if code == 125 {
+                    command = ""
+                } else if code == 126 {
+                    if let last = nav.session.cli.history.last {
+                        command = last.command
+                    }
+                }
+                return $0
             }
         }
         

--- a/DLPrototype/Views/Entities/Today/CommandLineInterface.swift
+++ b/DLPrototype/Views/Entities/Today/CommandLineInterface.swift
@@ -24,17 +24,6 @@ struct CommandLineInterface: View {
     
     @Environment(\.managedObjectContext) var moc
     @EnvironmentObject public var nav: Navigation
-    
-    // @TODO: move this down
-    struct CLICommand {
-        var domain: String
-        var method: String
-        var callback: (String, inout Navigation.CommandLineSession.History) -> Void
-        
-//        enum CLIValidDomain {
-//            case session
-//        }
-    }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 1) {
@@ -255,6 +244,12 @@ extension CommandLineInterface {
 }
 
 extension CommandLineInterface {
+    struct CLICommand {
+        var domain: String
+        var method: String
+        var callback: (String, inout Navigation.CommandLineSession.History) -> Void
+    }
+    
     struct App: View, Identifiable {
         var id: UUID = UUID()
         var type: AppType


### PR DESCRIPTION
* Set stuff (currently only the current session job) with `@session.job=number`
* Recall the previous item with the up arrow while in the command prompt
* Clear command prompt with the down arrow
* Status and messaging visual improvements