### PR TITLE
Main app nav icons can change icons depending on the chosen display mode

### DIFF
--- a/DLPrototype/Enums/TodayViewTab.swift
+++ b/DLPrototype/Enums/TodayViewTab.swift
@@ -14,7 +14,7 @@ public enum TodayViewTab: CaseIterable {
     var icon: String {
         switch self {
         case .chronologic:
-            return "tray.2.fill"
+            return "tray.fill"
         case .grouped:
             return "square.grid.3x1.fill.below.line.grid.1x2"
         case .summarized:

--- a/DLPrototype/Views/Home/Home.swift
+++ b/DLPrototype/Views/Home/Home.swift
@@ -19,6 +19,8 @@ struct Home: View {
     @AppStorage("isDatePickerPresented") public var isDatePickerPresented: Bool = false
     @AppStorage("CreateEntitiesWidget.isSearchStackShowing") private var isSearchStackShowing: Bool = false
     @AppStorage("general.showSessionInspector") public var showSessionInspector: Bool = false
+    @AppStorage("general.experimental.cli") private var cliEnabled: Bool = false
+    @AppStorage("today.commandLineMode") private var commandLineMode: Bool = false
 
     private var buttons: [PageGroup: [SidebarButton]] {
         [
@@ -42,7 +44,12 @@ struct Home: View {
                     pageType: .today,
                     icon: "doc.append",
                     label: "Today",
-                    sidebar: AnyView(TodaySidebar())
+                    sidebar: AnyView(TodaySidebar()),
+                    altMode: PageAltMode(
+                        name: "CLI Mode",
+                        icon: "apple.terminal",
+                        condition: cliEnabled && commandLineMode
+                    )
                 )
             ],
             .entities: [

--- a/DLPrototype/Views/Home/Home.swift
+++ b/DLPrototype/Views/Home/Home.swift
@@ -42,7 +42,7 @@ struct Home: View {
                 SidebarButton(
                     destination: AnyView(Today()),
                     pageType: .today,
-                    icon: "doc.append",
+                    icon: "tray",
                     label: "Today",
                     sidebar: AnyView(TodaySidebar()),
                     altMode: PageAltMode(

--- a/DLPrototype/Views/Shared/AppSidebar/SidebarButton.swift
+++ b/DLPrototype/Views/Shared/AppSidebar/SidebarButton.swift
@@ -74,7 +74,9 @@ struct SidebarButton: View, Identifiable {
                                             command: "@session.job=\(job.jid.string)",
                                             status: .success,
                                             message: "",
-                                            appType: .set)
+                                            appType: .set,
+                                            job: nav.session.job
+                                        )
                                     )
                                 }
                             }

--- a/DLPrototype/Views/Shared/AppSidebar/SidebarButton.swift
+++ b/DLPrototype/Views/Shared/AppSidebar/SidebarButton.swift
@@ -9,6 +9,13 @@
 import Foundation
 import SwiftUI
 
+struct PageAltMode: Identifiable {
+    var id: UUID = UUID()
+    var name: String
+    var icon: String
+    var condition: Bool
+}
+
 struct SidebarButton: View, Identifiable {
     public let id: UUID = UUID()
     public var destination: AnyView
@@ -18,6 +25,7 @@ struct SidebarButton: View, Identifiable {
     public var sidebar: AnyView?
     public var showLabel: Bool = true
     public var size: ButtonSize? = .large
+    public var altMode: PageAltMode? = nil
 
     @State private var highlighted: Bool = false
 
@@ -111,10 +119,11 @@ struct SidebarButton: View, Identifiable {
                     .opacity(0.1)
                 }
 
-                Image(systemName: isDatePickerPresented && nav.parent == pageType ? "xmark" : icon)
-                    .font(.title)
-                    .symbolRenderingMode(.hierarchical)
-                    .foregroundColor(isDatePickerPresented && nav.parent == pageType ? .black : highlighted ? .white : .white.opacity(0.8))
+                Image(systemName: isDatePickerPresented && nav.parent == pageType ? "xmark" : (altMode != nil ? (altMode!.condition ? altMode!.icon : icon) : icon))
+                   .font(.title)
+                   .symbolRenderingMode(.hierarchical)
+                   .foregroundColor(isDatePickerPresented && nav.parent == pageType ? .black : highlighted ? .white : .white.opacity(0.8))
+
             }
         })
         .help(label)


### PR DESCRIPTION
Use case is "when CLI mode is on, I want the Today page icon to reflect this and show me a terminal icon".