### PR TITLE
New experimental feature: CLI mode, filter list button

### DIFF
--- a/DLPrototype/Utils/Navigation.swift
+++ b/DLPrototype/Utils/Navigation.swift
@@ -216,18 +216,32 @@ extension Navigation {
         var app: CLIAppType = .log
         var selected: CLIApp?
 
-        public struct History: Identifiable {
+        public class History: Identifiable, NSCopying {
             public var id: UUID = UUID()
             var time: Date = Date()
             var command: String
             var status: Status = .standard
             var message: String
             var appType: CLIAppType
-            
+            var job: Job? = nil
+
+            init(time: Date = Date(), command: String, status: Status = .standard, message: String, appType: CLIAppType, job: Job?) {
+                self.time = time
+                self.command = command
+                self.status = status
+                self.message = message
+                self.appType = appType
+                self.job = job
+            }
+
             /// Converts a single history line item to it's string representation
             /// - Returns: String
             public func toString() -> String {
                 return "\(time.formatted(date: .abbreviated, time: .complete)) \(appType.name) \"\(command)\""
+            }
+
+            public func copy(with zone: NSZone? = nil) -> Any {
+                return History(time: time, command: command, status: status, message: message, appType: appType, job: job)
             }
 
             public enum Status {

--- a/DLPrototype/Views/Entities/Today/CommandLineInterface.swift
+++ b/DLPrototype/Views/Entities/Today/CommandLineInterface.swift
@@ -337,6 +337,7 @@ extension CommandLineInterface {
         var body: some View {
             VStack(spacing: 0) {
                 HStack {
+                    // @TODO: these widgets aren't ready for primetime yet
 //                    FancyDropdown(label: "Type", items: App.AppType.allCases)
 //                    FancyDropdown(label: "Date format", items: ["Date: Abbreviated, Time: Complete", "Date: Complete, Time: Complete"])
                     Spacer()

--- a/DLPrototype/Views/Entities/Today/PostingInterface.swift
+++ b/DLPrototype/Views/Entities/Today/PostingInterface.swift
@@ -151,7 +151,7 @@ extension Today.PostingInterface {
                 // Create a history item (used by CLI mode and, eventually, LogTable)
                 if nav.session.cli.history.count <= CommandLineInterface.maxItems {
                     nav.session.cli.history.append(
-                        Navigation.CommandLineSession.History(command: text, message: "", appType: .log)
+                        Navigation.CommandLineSession.History(command: text, message: "", appType: .log, job: nav.session.job)
                     )
                 }
             } catch {

--- a/DLPrototype/Views/Shared/Fancy/FancyTextField.swift
+++ b/DLPrototype/Views/Shared/Fancy/FancyTextField.swift
@@ -21,6 +21,7 @@ struct FancyTextField: View {
     public var showLabel: Bool = false
     public var font: Font = Theme.fontTextField
     public var fieldStatus: Navigation.Forms.Field.FieldStatus = .standard
+    public var padding: Double = 16
 
     @Binding public var text: String
 
@@ -55,7 +56,7 @@ struct FancyTextField: View {
             .font(font)
             .textFieldStyle(.plain)
             .disableAutocorrection(!enableAutoCorrection)
-            .padding()
+            .padding(padding)
             .onSubmit(onSubmit ?? {})
             .onChange(of: text) { newText in self.onChange != nil ? self.onChange!(newText) : nil }
             .background(fieldStatus == .standard ? (transparent! ? Color.clear : bgColour) : fieldStatus == .unsaved ? Color.yellow : Theme.cGreen) // sorry
@@ -72,7 +73,7 @@ struct FancyTextField: View {
             .font(font)
             .textFieldStyle(.plain)
             .disableAutocorrection(!enableAutoCorrection)
-            .padding()
+            .padding(padding)
             .onSubmit(onSubmit ?? {})
             .onChange(of: text) { newText in self.onChange != nil ? self.onChange!(newText) : nil }
             .background(fieldStatus == .standard ? (transparent! ? Color.clear : bgColour) : fieldStatus == .unsaved ? Color.yellow : Theme.cGreen) // sorry
@@ -88,7 +89,7 @@ struct FancyTextField: View {
             .font(Theme.fontSubTitle)
             .textFieldStyle(.plain)
             .disableAutocorrection(!enableAutoCorrection)
-            .padding()
+            .padding(padding)
             .onSubmit(onSubmit ?? {})
             .onChange(of: text) { newText in self.onChange != nil ? self.onChange!(newText) : nil }
             .background(fieldStatus == .standard ? (transparent! ? Color.clear : bgColour) : fieldStatus == .unsaved ? Color.yellow : Theme.cGreen) // sorry{}


### PR DESCRIPTION
Allow filtering of the display in CLI mode. This is different from the other search bars in that it will only look within the `cli.history` object instead of, for example, allowing you to perform arbitrary text searches on today's submitted Records. The icon has been changed from a magnifying glass to visually imply this distinction as well.