### PR TITLE
Bugfixes: Empty string logged in CLI mode, 1px gap between tabs and content

### DIFF
--- a/DLPrototype/Views/Entities/Today/PostingInterface.swift
+++ b/DLPrototype/Views/Entities/Today/PostingInterface.swift
@@ -145,7 +145,6 @@ extension Today.PostingInterface {
                 try record.validateForInsert()
 
                 PersistenceController.shared.save()
-                text = ""
                 nav.session.idate = DateHelper.identifiedDate(for: Date(), moc: moc)
 
                 // Create a history item (used by CLI mode and, eventually, LogTable)
@@ -154,6 +153,8 @@ extension Today.PostingInterface {
                         Navigation.CommandLineSession.History(command: text, message: "", appType: .log, job: nav.session.job)
                     )
                 }
+
+                text = ""
             } catch {
                 print("[error] Save error \(error)")
             }

--- a/DLPrototype/Views/Shared/Fancy/FancyGenericToolbar.swift
+++ b/DLPrototype/Views/Shared/Fancy/FancyGenericToolbar.swift
@@ -86,7 +86,7 @@ struct FancyGenericToolbar: View {
                     }
                 }
             }
-            .frame(height: 33)
+            .frame(height: 32)
 
             GridRow {
                 Group {


### PR DESCRIPTION
* Empty string logged in CLI mode
* 1px gap between tabs and content