### PR TITLE
New feature: unified sidebar widget

### DIFF
--- a/DLPrototype.xcodeproj/project.pbxproj
+++ b/DLPrototype.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		53013A982CAC60200024BA30 /* Company.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53013A972CAC601F0024BA30 /* Company.swift */; };
 		53013A9A2CAC8C530024BA30 /* DefinitionDetail.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53013A992CAC8C510024BA30 /* DefinitionDetail.swift */; };
 		53013A9C2CAC9CCA0024BA30 /* DefinitionSidebar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53013A9B2CAC9CC40024BA30 /* DefinitionSidebar.swift */; };
+		53013A9F2CACD23D0024BA30 /* RowAddButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53013A9E2CACD23D0024BA30 /* RowAddButton.swift */; };
 		530168172A887B0A000AF4FD /* AllJobsPickerWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 530168162A887B0A000AF4FD /* AllJobsPickerWidget.swift */; };
 		530318472A11DD13009CA90B /* CoreDataCalendarEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 530318462A11DD13009CA90B /* CoreDataCalendarEvent.swift */; };
 		5309EE3D25619A6D00B3BC06 /* Backup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5309EE3C25619A6D00B3BC06 /* Backup.swift */; };
@@ -259,6 +260,7 @@
 		53013A972CAC601F0024BA30 /* Company.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Company.swift; sourceTree = "<group>"; };
 		53013A992CAC8C510024BA30 /* DefinitionDetail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefinitionDetail.swift; sourceTree = "<group>"; };
 		53013A9B2CAC9CC40024BA30 /* DefinitionSidebar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefinitionSidebar.swift; sourceTree = "<group>"; };
+		53013A9E2CACD23D0024BA30 /* RowAddButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = RowAddButton.swift; path = "../klockwork-ios/KlockWork-iOS/KlockWork-iOS/SharedViews/RowAddButton.swift"; sourceTree = "<group>"; };
 		530168162A887B0A000AF4FD /* AllJobsPickerWidget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AllJobsPickerWidget.swift; sourceTree = "<group>"; };
 		530318462A11DD13009CA90B /* CoreDataCalendarEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreDataCalendarEvent.swift; sourceTree = "<group>"; };
 		5309EE3C25619A6D00B3BC06 /* Backup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Backup.swift; sourceTree = "<group>"; };
@@ -567,6 +569,7 @@
 		53218D3B24B7F6EB0088ABE9 = {
 			isa = PBXGroup;
 			children = (
+				53013A9E2CACD23D0024BA30 /* RowAddButton.swift */,
 				53CEDBD32CAA014B002726DC /* FilterField.swift */,
 				53CEDBC72CA9FFA3002726DC /* PageConfiguration.swift */,
 				537DFF862BF27F0B00FC5923 /* PRIVACY.md */,
@@ -1372,6 +1375,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				53013A9F2CACD23D0024BA30 /* RowAddButton.swift in Sources */,
 				53CEDBD42CAA014B002726DC /* FilterField.swift in Sources */,
 				53CEDBC82CA9FFA3002726DC /* PageConfiguration.swift in Sources */,
 				53FEF578296603D9000B94FC /* FancyTextField.swift in Sources */,

--- a/DLPrototype/Models/CoreData/CoreDataCompanies.swift
+++ b/DLPrototype/Models/CoreData/CoreDataCompanies.swift
@@ -28,20 +28,28 @@ public class CoreDataCompanies: ObservableObject {
     }
 
     /// Fetch request to find all items
+    /// - Parameter allowKilled: Bool
     /// - Returns: FetchRequest<Company>
-    static public func all() -> FetchRequest<Company> {
+    static public func all(_ allowKilled: Bool = false) -> FetchRequest<Company> {
         let descriptors = [
             NSSortDescriptor(keyPath: \Company.name, ascending: true)
         ]
 
         let fetch: NSFetchRequest<Company> = Company.fetchRequest()
-        fetch.predicate = NSPredicate(format: "alive == true && hidden == false")
+
+        if allowKilled {
+            fetch.predicate = NSPredicate(format: "hidden == false")
+        } else {
+            fetch.predicate = NSPredicate(format: "alive == true && hidden == false")
+        }
+
         fetch.sortDescriptors = descriptors
 
         return FetchRequest(fetchRequest: fetch, animation: .easeInOut)
     }
 
     /// Finds all active companies
+    /// - Parameter allowKilled: Bool
     /// - Returns: FetchRequest<Company>
     static public func fetch(_ allowKilled: Bool = false) -> FetchRequest<Company> {
         let descriptors = [
@@ -141,6 +149,17 @@ public class CoreDataCompanies: ObservableObject {
     public func active() -> [Company] {
         let predicate = NSPredicate(
             format: "alive == true"
+        )
+
+        return query(predicate)
+    }
+
+    /// Fetch request to find all items
+    /// - Returns: FetchRequest<Company>
+    public func all(allowKilled: Bool = false) -> [Company] {
+        let predicate = NSPredicate(
+            format: !allowKilled ? "createdDate < %@" : "alive == true && createdDate < %@",
+            Date() as CVarArg
         )
 
         return query(predicate)

--- a/DLPrototype/Models/CoreData/CoreDataCompanies.swift
+++ b/DLPrototype/Models/CoreData/CoreDataCompanies.swift
@@ -354,7 +354,7 @@ public class CoreDataCompanies: ObservableObject {
 
         var results: [Company] = []
         let fetch: NSFetchRequest<Company> = Company.fetchRequest()
-        fetch.sortDescriptors = [NSSortDescriptor(keyPath: \Company.name?, ascending: false)]
+        fetch.sortDescriptors = [NSSortDescriptor(keyPath: \Company.name?, ascending: true)]
 
         if predicate != nil {
             fetch.predicate = predicate

--- a/DLPrototype/Models/CoreData/CoreDataCompanies.swift
+++ b/DLPrototype/Models/CoreData/CoreDataCompanies.swift
@@ -354,7 +354,10 @@ public class CoreDataCompanies: ObservableObject {
 
         var results: [Company] = []
         let fetch: NSFetchRequest<Company> = Company.fetchRequest()
-        fetch.sortDescriptors = [NSSortDescriptor(keyPath: \Company.name?, ascending: true)]
+        fetch.sortDescriptors = [
+            NSSortDescriptor(keyPath: \Company.name?, ascending: true),
+            NSSortDescriptor(keyPath: \Company.createdDate?, ascending: true)
+        ]
 
         if predicate != nil {
             fetch.predicate = predicate

--- a/DLPrototype/Models/CoreData/CoreDataCompanies.swift
+++ b/DLPrototype/Models/CoreData/CoreDataCompanies.swift
@@ -43,13 +43,18 @@ public class CoreDataCompanies: ObservableObject {
 
     /// Finds all active companies
     /// - Returns: FetchRequest<Company>
-    static public func fetch() -> FetchRequest<Company> {
+    static public func fetch(_ allowKilled: Bool = false) -> FetchRequest<Company> {
         let descriptors = [
             NSSortDescriptor(keyPath: \Company.name, ascending: true),
         ]
 
         let fetch: NSFetchRequest<Company> = Company.fetchRequest()
-        fetch.predicate = NSPredicate(format: "alive == true")
+
+        if allowKilled {
+            fetch.predicate = NSPredicate(format: "createdDate < %@", Date() as CVarArg)
+        } else {
+            fetch.predicate = NSPredicate(format: "alive == true")
+        }
         fetch.sortDescriptors = descriptors
 
         return FetchRequest(fetchRequest: fetch, animation: .easeInOut)

--- a/DLPrototype/Utils/Navigation.swift
+++ b/DLPrototype/Utils/Navigation.swift
@@ -9,7 +9,7 @@
 import SwiftUI
 
 public enum Page {
-    case dashboard, today, notes, tasks, projects, jobs, companies, planning, terms, definitionDetail
+    case dashboard, today, notes, tasks, projects, jobs, companies, planning, terms, definitionDetail, taskDetail
 
     var ViewUpdaterKey: String {
         switch self {
@@ -32,6 +32,7 @@ public enum Page {
         case .terms:
             return "terms.dashboard"
         case .definitionDetail: return "terms.definition.detail"
+        case .taskDetail: return "terms.definition.tasks"
         }
     }
 
@@ -56,6 +57,8 @@ public enum Page {
         case .terms:
             return PageConfiguration.AppPage.explore.primaryColour
         case .definitionDetail:
+            return PageConfiguration.AppPage.explore.primaryColour
+        case .taskDetail:
             return PageConfiguration.AppPage.explore.primaryColour
         }
     }
@@ -82,6 +85,7 @@ public enum Page {
             return "Terms"
         case .definitionDetail:
             return "Definition"
+        case .taskDetail: return "Task"
         }
     }
 }
@@ -561,6 +565,7 @@ extension Navigation {
             HistoryPage(page: .tasks, view: AnyView(TaskDashboard()), sidebar: AnyView(TaskDashboardSidebar()), title: "Tasks"),
             HistoryPage(page: .terms, view: AnyView(TermsDashboard()), sidebar: AnyView(TermsDashboardSidebar()), title: "Terms"),
             HistoryPage(page: .definitionDetail, view: AnyView(DefinitionDetail()), sidebar: AnyView(TermsDashboardSidebar()), title: "Definition detail"),
+            HistoryPage(page: .taskDetail, view: AnyView(EmptyView()), sidebar: AnyView(TermsDashboardSidebar()), title: "Task detail"),
         ]
         
         /// A single page representing a page the user navigated to

--- a/DLPrototype/Utils/Navigation.swift
+++ b/DLPrototype/Utils/Navigation.swift
@@ -9,7 +9,7 @@
 import SwiftUI
 
 public enum Page {
-    case dashboard, today, notes, tasks, projects, jobs, companies, planning, terms, definitionDetail, taskDetail
+    case dashboard, today, notes, tasks, projects, jobs, companies, planning, terms, definitionDetail, taskDetail, noteDetail
 
     var ViewUpdaterKey: String {
         switch self {
@@ -32,7 +32,8 @@ public enum Page {
         case .terms:
             return "terms.dashboard"
         case .definitionDetail: return "terms.definition.detail"
-        case .taskDetail: return "terms.definition.tasks"
+        case .taskDetail: return "task.detail"
+        case .noteDetail: return "note.detail"
         }
     }
 
@@ -60,6 +61,8 @@ public enum Page {
             return PageConfiguration.AppPage.explore.primaryColour
         case .taskDetail:
             return PageConfiguration.AppPage.explore.primaryColour
+        case .noteDetail:
+            return PageConfiguration.AppPage.explore.primaryColour
         }
     }
 
@@ -86,6 +89,7 @@ public enum Page {
         case .definitionDetail:
             return "Definition"
         case .taskDetail: return "Task"
+        case .noteDetail: return "Note"
         }
     }
 }
@@ -566,6 +570,7 @@ extension Navigation {
             HistoryPage(page: .terms, view: AnyView(TermsDashboard()), sidebar: AnyView(TermsDashboardSidebar()), title: "Terms"),
             HistoryPage(page: .definitionDetail, view: AnyView(DefinitionDetail()), sidebar: AnyView(TermsDashboardSidebar()), title: "Definition detail"),
             HistoryPage(page: .taskDetail, view: AnyView(EmptyView()), sidebar: AnyView(TermsDashboardSidebar()), title: "Task detail"),
+            HistoryPage(page: .noteDetail, view: AnyView(NoteCreate()), sidebar: AnyView(NoteCreateSidebar()), title: "Note detail"),
         ]
         
         /// A single page representing a page the user navigated to

--- a/DLPrototype/Views/Dashboard/Sidebars/DashboardSidebar.swift
+++ b/DLPrototype/Views/Dashboard/Sidebars/DashboardSidebar.swift
@@ -12,11 +12,8 @@ struct DashboardSidebar: View {
     @State private var tabs: [ToolbarButton] = []
 
     var body: some View {
-        ScrollView(showsIndicators: false) {
-            VStack(alignment: .leading, spacing: 5) {
-                FancyGenericToolbar(buttons: tabs, standalone: true, location: .sidebar)
-            }
-            Spacer()
+        VStack(alignment: .leading, spacing: 5) {
+            FancyGenericToolbar(buttons: tabs, standalone: true, location: .sidebar)
         }
         .onAppear(perform: createToolbar)
     }
@@ -30,9 +27,10 @@ extension DashboardSidebar {
                 helpText: "Today in history",
                 label: AnyView(
                     HStack {
-                        Image(systemName: "calendar").padding(.leading)
+                        Image(systemName: "calendar")
                         Text("History")
                     }
+                        .padding([.leading, .trailing], 10)
                 ),
                 contents: AnyView(TodayInHistoryWidget())
             ),
@@ -41,12 +39,25 @@ extension DashboardSidebar {
                 helpText: "Companies & Projects",
                 label: AnyView(
                     HStack {
-                        Image(systemName: "menucard").padding(.leading)
+                        Image(systemName: "menucard")
                         Text("Outline")
                     }
+                        .padding([.leading, .trailing], 10)
                 ),
                 contents: AnyView(OutlineWidget())
             ),
+            ToolbarButton(
+                id: 2,
+                helpText: "Resources",
+                label: AnyView(
+                    HStack {
+                        Image(systemName: "globe.americas")
+                        Text("Resources")
+                    }
+                        .padding([.leading, .trailing], 10)
+                ),
+                contents: AnyView(JobsWidgetRedux())
+            )
         ]
     }
 }

--- a/DLPrototype/Views/Dashboard/Sidebars/DashboardSidebar.swift
+++ b/DLPrototype/Views/Dashboard/Sidebars/DashboardSidebar.swift
@@ -18,7 +18,6 @@ struct DashboardSidebar: View {
             }
             Spacer()
         }
-        .padding()
         .onAppear(perform: createToolbar)
     }
 }

--- a/DLPrototype/Views/Entities/Companies/CompanyDashboard.swift
+++ b/DLPrototype/Views/Entities/Companies/CompanyDashboard.swift
@@ -22,6 +22,7 @@ struct CompanyDashboard: View {
     @FetchRequest public var companies: FetchedResults<Company>
 
     private let page: PageConfiguration.AppPage = .explore
+    private let eType: PageConfiguration.EntityType = .companies
     private var columns: [GridItem] {
         Array(repeating: .init(.flexible(minimum: 100)), count: numColumns)
     }
@@ -30,7 +31,7 @@ struct CompanyDashboard: View {
         VStack(alignment: .leading) {
             VStack(alignment: .leading) {
                 HStack {
-                    Title(text: "Companies & Projects")
+                    Title(text: "Companies & Projects", imageAsImage: eType.icon)
                     Spacer()
                     FancyButtonv2(
                         text: "New Company",

--- a/DLPrototype/Views/Entities/Companies/Sidebars/DefaultCompanySidebar.swift
+++ b/DLPrototype/Views/Entities/Companies/Sidebars/DefaultCompanySidebar.swift
@@ -15,11 +15,8 @@ struct DefaultCompanySidebar: View {
     @EnvironmentObject public var nav: Navigation
 
     var body: some View {
-        ScrollView(showsIndicators: false) {
-            VStack(alignment: .leading, spacing: 5) {
-                FancyGenericToolbar(buttons: tabs, standalone: true, location: .sidebar, mode: .compact)
-            }
-            Spacer()
+        VStack(alignment: .leading, spacing: 5) {
+            FancyGenericToolbar(buttons: tabs, standalone: true, location: .sidebar, mode: .compact)
         }
         .onAppear(perform: createToolbar)
     }

--- a/DLPrototype/Views/Entities/Companies/Sidebars/DefaultCompanySidebar.swift
+++ b/DLPrototype/Views/Entities/Companies/Sidebars/DefaultCompanySidebar.swift
@@ -21,7 +21,6 @@ struct DefaultCompanySidebar: View {
             }
             Spacer()
         }
-        .padding()
         .onAppear(perform: createToolbar)
     }
 }

--- a/DLPrototype/Views/Entities/Companies/Sidebars/DefaultCompanySidebar.swift
+++ b/DLPrototype/Views/Entities/Companies/Sidebars/DefaultCompanySidebar.swift
@@ -27,7 +27,14 @@ extension DefaultCompanySidebar {
         tabs = [
             ToolbarButton(
                 id: 0,
-                helpText: "Companies & Projects",
+                helpText: "Resources",
+                icon: "globe.americas",
+                labelText: "Resources",
+                contents: AnyView(JobsWidgetRedux())
+            ),
+            ToolbarButton(
+                id: 1,
+                helpText: "Outline",
                 icon: "menucard",
                 labelText: "Outline",
                 contents: AnyView(OutlineWidget())

--- a/DLPrototype/Views/Entities/Jobs/JobDashboard.swift
+++ b/DLPrototype/Views/Entities/Jobs/JobDashboard.swift
@@ -83,16 +83,13 @@ struct JobDashboardRedux: View {
     @Environment(\.managedObjectContext) var moc
     @EnvironmentObject private var nav: Navigation
     private let page: PageConfiguration.AppPage = .explore
+    private let eType: PageConfiguration.EntityType = .jobs
 
     var body: some View {
         VStack(alignment: .leading) {
             VStack(alignment: .leading, spacing: 1) {
                 HStack {
-                    HStack(spacing: 10) {
-                        Image(systemName: "hammer")
-                        Text("Jobs")
-                    }
-                    .font(.title2)
+                    Title(text: eType.label, imageAsImage: eType.icon)
                     Spacer()
                     FancyButtonv2(
                         text: "Create",

--- a/DLPrototype/Views/Entities/Jobs/Sidebars/JobDashboardSidebar.swift
+++ b/DLPrototype/Views/Entities/Jobs/Sidebars/JobDashboardSidebar.swift
@@ -30,7 +30,7 @@ extension JobDashboardSidebar {
         tabs = [
             ToolbarButton(
                 id: 0,
-                helpText: "Find resources",
+                helpText: "Resources",
                 icon: "globe.americas",
                 labelText: "Resources",
                 contents: AnyView(JobsWidgetRedux())

--- a/DLPrototype/Views/Entities/Jobs/Sidebars/JobDashboardSidebar.swift
+++ b/DLPrototype/Views/Entities/Jobs/Sidebars/JobDashboardSidebar.swift
@@ -24,7 +24,6 @@ struct JobDashboardSidebar: View {
             }
             Spacer()
         }
-        .padding()
         .onAppear(perform: createToolbar)
     }
 }
@@ -34,13 +33,20 @@ extension JobDashboardSidebar {
         tabs = [
             ToolbarButton(
                 id: 0,
+                helpText: "Find resources",
+                icon: "globe.americas",
+                labelText: "Resources",
+                contents: AnyView(JobsWidgetRedux())
+            ),
+            ToolbarButton(
+                id: 1,
                 helpText: "Recent jobs",
                 icon: "clock",
                 labelText: "Recent jobs",
                 contents: AnyView(JobPickerWidget())
             ),
             ToolbarButton(
-                id: 1,
+                id: 2,
                 helpText: "All jobs",
                 icon: "hammer",
                 labelText: "All Jobs",

--- a/DLPrototype/Views/Entities/Jobs/Sidebars/JobDashboardSidebar.swift
+++ b/DLPrototype/Views/Entities/Jobs/Sidebars/JobDashboardSidebar.swift
@@ -37,17 +37,10 @@ extension JobDashboardSidebar {
             ),
             ToolbarButton(
                 id: 1,
-                helpText: "Recent jobs",
-                icon: "clock",
-                labelText: "Recent jobs",
-                contents: AnyView(JobPickerWidget())
-            ),
-            ToolbarButton(
-                id: 2,
-                helpText: "All jobs",
-                icon: "hammer",
-                labelText: "All Jobs",
-                contents: AnyView(JobsWidget())
+                helpText: "Outline",
+                icon: "menucard",
+                labelText: "Outline",
+                contents: AnyView(OutlineWidget())
             )
         ]
     }

--- a/DLPrototype/Views/Entities/Jobs/Sidebars/JobDashboardSidebar.swift
+++ b/DLPrototype/Views/Entities/Jobs/Sidebars/JobDashboardSidebar.swift
@@ -13,16 +13,13 @@ struct JobDashboardSidebar: View {
     @State private var searching: Bool = false
 
     var body: some View {
-        ScrollView(showsIndicators: false) {
-            VStack(alignment: .leading, spacing: 5) {
-                FancyGenericToolbar(
-                    buttons: tabs,
-                    standalone: true,
-                    location: .sidebar,
-                    mode: .compact
-                )
-            }
-            Spacer()
+        VStack(alignment: .leading, spacing: 5) {
+            FancyGenericToolbar(
+                buttons: tabs,
+                standalone: true,
+                location: .sidebar,
+                mode: .compact
+            )
         }
         .onAppear(perform: createToolbar)
     }

--- a/DLPrototype/Views/Entities/Notes/NoteDashboard.swift
+++ b/DLPrototype/Views/Entities/Notes/NoteDashboard.swift
@@ -29,6 +29,7 @@ struct NoteDashboard: View {
     @FetchRequest public var notes: FetchedResults<Note>
 
     private let page: PageConfiguration.AppPage = .explore
+    private let eType: PageConfiguration.EntityType = .notes
 
     private var columns: [GridItem] {
         return Array(repeating: .init(.flexible(minimum: 100)), count: numColumns)
@@ -67,8 +68,7 @@ struct NoteDashboard: View {
         VStack(alignment: .leading) {
             VStack(alignment: .leading, spacing: 1) {
                 HStack(spacing: 10) {
-                    Image(systemName: "note.text")
-                    Text("Notes")
+                    Title(text: eType.label, imageAsImage: eType.icon)
                     Spacer()
                     FancyButtonv2(
                         text: "Create",

--- a/DLPrototype/Views/Entities/Notes/Sidebars/NoteCreateSidebar.swift
+++ b/DLPrototype/Views/Entities/Notes/Sidebars/NoteCreateSidebar.swift
@@ -15,18 +15,14 @@ struct NoteCreateSidebar: View {
     @State private var searching: Bool = false
 
     var body: some View {
-        ScrollView(showsIndicators: false) {
-            VStack(alignment: .leading, spacing: 5) {
-                FancyGenericToolbar(
-                    buttons: tabs,
-                    standalone: true,
-                    location: .sidebar,
-                    mode: .compact
-                )
-            }
-            Spacer()
+        VStack(alignment: .leading, spacing: 5) {
+            FancyGenericToolbar(
+                buttons: tabs,
+                standalone: true,
+                location: .sidebar,
+                mode: .compact
+            )
         }
-        .padding()
         .onAppear(perform: createToolbar)
     }
 }

--- a/DLPrototype/Views/Entities/Notes/Sidebars/NoteDashboardSidebar.swift
+++ b/DLPrototype/Views/Entities/Notes/Sidebars/NoteDashboardSidebar.swift
@@ -37,10 +37,10 @@ extension NoteDashboardSidebar {
             ),
             ToolbarButton(
                 id: 1,
-                helpText: "Notes",
-                icon: "note.text",
-                labelText: "Notes",
-                contents: AnyView(NotesWidget())
+                helpText: "Outline",
+                icon: "menucard",
+                labelText: "Outline",
+                contents: AnyView(OutlineWidget())
             ),
             ToolbarButton(
                 id: 2,

--- a/DLPrototype/Views/Entities/Notes/Sidebars/NoteDashboardSidebar.swift
+++ b/DLPrototype/Views/Entities/Notes/Sidebars/NoteDashboardSidebar.swift
@@ -24,7 +24,6 @@ struct NoteDashboardSidebar: View {
             }
             Spacer()
         }
-        .padding()
         .onAppear(perform: createToolbar)
     }
 }
@@ -34,13 +33,20 @@ extension NoteDashboardSidebar {
         tabs = [
             ToolbarButton(
                 id: 0,
+                helpText: "Find resources",
+                icon: "globe.americas",
+                labelText: "Resources",
+                contents: AnyView(JobsWidgetRedux())
+            ),
+            ToolbarButton(
+                id: 1,
                 helpText: "Notes",
                 icon: "note.text",
                 labelText: "Notes",
                 contents: AnyView(NotesWidget())
             ),
             ToolbarButton(
-                id: 1,
+                id: 2,
                 helpText: "Favourites notes",
                 icon: "star.fill",
                 labelText: "Favourite Notes",

--- a/DLPrototype/Views/Entities/Notes/Sidebars/NoteDashboardSidebar.swift
+++ b/DLPrototype/Views/Entities/Notes/Sidebars/NoteDashboardSidebar.swift
@@ -30,7 +30,7 @@ extension NoteDashboardSidebar {
         tabs = [
             ToolbarButton(
                 id: 0,
-                helpText: "Find resources",
+                helpText: "Resources",
                 icon: "globe.americas",
                 labelText: "Resources",
                 contents: AnyView(JobsWidgetRedux())

--- a/DLPrototype/Views/Entities/Notes/Sidebars/NoteDashboardSidebar.swift
+++ b/DLPrototype/Views/Entities/Notes/Sidebars/NoteDashboardSidebar.swift
@@ -13,16 +13,13 @@ struct NoteDashboardSidebar: View {
     @State private var searching: Bool = false
 
     var body: some View {
-        ScrollView(showsIndicators: false) {
-            VStack(alignment: .leading, spacing: 5) {
-                FancyGenericToolbar(
-                    buttons: tabs,
-                    standalone: true,
-                    location: .sidebar,
-                    mode: .compact
-                )
-            }
-            Spacer()
+        VStack(alignment: .leading, spacing: 5) {
+            FancyGenericToolbar(
+                buttons: tabs,
+                standalone: true,
+                location: .sidebar,
+                mode: .compact
+            )
         }
         .onAppear(perform: createToolbar)
     }

--- a/DLPrototype/Views/Entities/Projects/ProjectView.swift
+++ b/DLPrototype/Views/Entities/Projects/ProjectView.swift
@@ -272,11 +272,15 @@ struct ProjectView: View {
                                                 })
                                             }
 
-                                            if project.configuration!.ignoredJobs!.contains(job.jid.string) {
-                                                FancyButton(text: "Hide from exports", action: {disableExport(job.jid.string)}, icon: "eye.slash", transparent: true, showLabel: false)
-                                                    .opacity(0.3)
-                                            } else {
-                                                FancyButton(text: "Included in exports", action: {enableExport(job.jid.string)}, icon: "eye", transparent: true, showLabel: false)
+                                            if let conf = project.configuration {
+                                                if let ignored = conf.ignoredJobs {
+                                                    if ignored.contains(job.jid.string) {
+                                                        FancyButton(text: "Hide from exports", action: {disableExport(job.jid.string)}, icon: "eye.slash", transparent: true, showLabel: false)
+                                                            .opacity(0.3)
+                                                    } else {
+                                                        FancyButton(text: "Included in exports", action: {enableExport(job.jid.string)}, icon: "eye", transparent: true, showLabel: false)
+                                                    }
+                                                }
                                             }
                                         }
                                         .padding([.leading, .trailing], 5)

--- a/DLPrototype/Views/Entities/Tasks/Sidebars/TaskDashboardSidebar.swift
+++ b/DLPrototype/Views/Entities/Tasks/Sidebars/TaskDashboardSidebar.swift
@@ -13,16 +13,13 @@ struct TaskDashboardSidebar: View {
     @State private var searching: Bool = false
 
     var body: some View {
-        ScrollView(showsIndicators: false) {
-            VStack(alignment: .leading, spacing: 5) {
-                FancyGenericToolbar(
-                    buttons: tabs,
-                    standalone: true,
-                    location: .sidebar,
-                    mode: .compact
-                )
-            }
-            Spacer()
+        VStack(alignment: .leading, spacing: 5) {
+            FancyGenericToolbar(
+                buttons: tabs,
+                standalone: true,
+                location: .sidebar,
+                mode: .compact
+            )
         }
         .onAppear(perform: createToolbar)
     }

--- a/DLPrototype/Views/Entities/Tasks/Sidebars/TaskDashboardSidebar.swift
+++ b/DLPrototype/Views/Entities/Tasks/Sidebars/TaskDashboardSidebar.swift
@@ -37,10 +37,10 @@ extension TaskDashboardSidebar {
             ),
             ToolbarButton(
                 id: 1,
-                helpText: "Tasks",
-                icon: "checklist",
-                labelText: "Tasks",
-                contents: AnyView(TasksWidget())
+                helpText: "Outline",
+                icon: "menucard",
+                labelText: "Outline",
+                contents: AnyView(OutlineWidget())
             )
         ]
     }

--- a/DLPrototype/Views/Entities/Tasks/Sidebars/TaskDashboardSidebar.swift
+++ b/DLPrototype/Views/Entities/Tasks/Sidebars/TaskDashboardSidebar.swift
@@ -24,7 +24,6 @@ struct TaskDashboardSidebar: View {
             }
             Spacer()
         }
-        .padding()
         .onAppear(perform: createToolbar)
     }
 }
@@ -34,6 +33,13 @@ extension TaskDashboardSidebar {
         tabs = [
             ToolbarButton(
                 id: 0,
+                helpText: "Find resources",
+                icon: "globe.americas",
+                labelText: "Resources",
+                contents: AnyView(JobsWidgetRedux())
+            ),
+            ToolbarButton(
+                id: 1,
                 helpText: "Tasks",
                 icon: "checklist",
                 labelText: "Tasks",

--- a/DLPrototype/Views/Entities/Tasks/Sidebars/TaskDashboardSidebar.swift
+++ b/DLPrototype/Views/Entities/Tasks/Sidebars/TaskDashboardSidebar.swift
@@ -30,7 +30,7 @@ extension TaskDashboardSidebar {
         tabs = [
             ToolbarButton(
                 id: 0,
-                helpText: "Find resources",
+                helpText: "Resources",
                 icon: "globe.americas",
                 labelText: "Resources",
                 contents: AnyView(JobsWidgetRedux())

--- a/DLPrototype/Views/Entities/Tasks/TaskDashboard.swift
+++ b/DLPrototype/Views/Entities/Tasks/TaskDashboard.swift
@@ -12,6 +12,7 @@ import SwiftUI
 struct TaskDashboard: View {
     public var defaultSelectedJob: Job?
     private let page: PageConfiguration.AppPage = .explore
+    private let eType: PageConfiguration.EntityType = .tasks
 
     @State private var searchText: String = ""
     @State private var selectedJob: Int = 0
@@ -29,6 +30,19 @@ struct TaskDashboard: View {
     var body: some View {
         VStack(alignment: .leading) {
             VStack(alignment: .leading) {
+                HStack(alignment: .center, spacing: 0) {
+                    Title(text: eType.label, imageAsImage: eType.icon)
+                    Spacer()
+                    FancyButtonv2(
+                        text: "Create",
+                        action: {
+
+                        },
+                        icon: "plus",
+                        showLabel: false
+                    )
+                }
+                FancyDivider()
                 search.font(Theme.font)
                 create
 

--- a/DLPrototype/Views/Entities/Terms/Sidebars/TermsDashboardSidebar.swift
+++ b/DLPrototype/Views/Entities/Terms/Sidebars/TermsDashboardSidebar.swift
@@ -30,7 +30,7 @@ extension TermsDashboardSidebar {
         tabs = [
             ToolbarButton(
                 id: 0,
-                helpText: "Find resources",
+                helpText: "Resources",
                 icon: "globe.americas",
                 labelText: "Resources",
                 contents: AnyView(JobsWidgetRedux())

--- a/DLPrototype/Views/Entities/Terms/Sidebars/TermsDashboardSidebar.swift
+++ b/DLPrototype/Views/Entities/Terms/Sidebars/TermsDashboardSidebar.swift
@@ -13,15 +13,13 @@ struct TermsDashboardSidebar: View {
     @State private var searching: Bool = false
 
     var body: some View {
-        ScrollView(showsIndicators: false) {
-            VStack(alignment: .leading, spacing: 0) {
-                FancyGenericToolbar(
-                    buttons: tabs,
-                    standalone: true,
-                    location: .sidebar,
-                    mode: .compact
-                )
-            }
+        VStack(alignment: .leading, spacing: 0) {
+            FancyGenericToolbar(
+                buttons: tabs,
+                standalone: true,
+                location: .sidebar,
+                mode: .compact
+            )
         }
         .onAppear(perform: createToolbar)
     }
@@ -36,13 +34,6 @@ extension TermsDashboardSidebar {
                 icon: "globe.americas",
                 labelText: "Resources",
                 contents: AnyView(JobsWidgetRedux())
-            ),
-            ToolbarButton(
-                id: 1,
-                helpText: "Recent jobs",
-                icon: "clock",
-                labelText: "Recent jobs",
-                contents: AnyView(JobPickerWidget())
             )
         ]
     }

--- a/DLPrototype/Views/Entities/Terms/Sidebars/TermsDashboardSidebar.swift
+++ b/DLPrototype/Views/Entities/Terms/Sidebars/TermsDashboardSidebar.swift
@@ -14,7 +14,7 @@ struct TermsDashboardSidebar: View {
 
     var body: some View {
         ScrollView(showsIndicators: false) {
-            VStack(alignment: .leading, spacing: 5) {
+            VStack(alignment: .leading, spacing: 0) {
                 FancyGenericToolbar(
                     buttons: tabs,
                     standalone: true,
@@ -22,9 +22,7 @@ struct TermsDashboardSidebar: View {
                     mode: .compact
                 )
             }
-            Spacer()
         }
-        .padding()
         .onAppear(perform: createToolbar)
     }
 }
@@ -34,17 +32,17 @@ extension TermsDashboardSidebar {
         tabs = [
             ToolbarButton(
                 id: 0,
+                helpText: "Find resources",
+                icon: "globe.americas",
+                labelText: "Resources",
+                contents: AnyView(JobsWidgetRedux())
+            ),
+            ToolbarButton(
+                id: 1,
                 helpText: "Recent jobs",
                 icon: "clock",
                 labelText: "Recent jobs",
                 contents: AnyView(JobPickerWidget())
-            ),
-            ToolbarButton(
-                id: 1,
-                helpText: "All jobs",
-                icon: "hammer",
-                labelText: "All Jobs",
-                contents: AnyView(JobsWidget())
             )
         ]
     }

--- a/DLPrototype/Views/Entities/Terms/Sidebars/TermsDashboardSidebar.swift
+++ b/DLPrototype/Views/Entities/Terms/Sidebars/TermsDashboardSidebar.swift
@@ -34,6 +34,13 @@ extension TermsDashboardSidebar {
                 icon: "globe.americas",
                 labelText: "Resources",
                 contents: AnyView(JobsWidgetRedux())
+            ),
+            ToolbarButton(
+                id: 1,
+                helpText: "Outline",
+                icon: "menucard",
+                labelText: "Outline",
+                contents: AnyView(OutlineWidget())
             )
         ]
     }

--- a/DLPrototype/Views/Entities/Terms/TermsDashboard.swift
+++ b/DLPrototype/Views/Entities/Terms/TermsDashboard.swift
@@ -24,7 +24,7 @@ struct TermsDashboard: View {
         NavigationStack {
             VStack(alignment: .leading, spacing: 1) {
                 HStack(alignment: .center, spacing: 0) {
-                    Title(text: eType.label, imageAsImage: eType.icon)
+                    Title(text: "Terms & Definitions", imageAsImage: eType.icon)
                     Spacer()
                     FancyButtonv2(text: "Create term", action: self.actionOnTap, icon: "plus", showLabel: false)
                 }

--- a/DLPrototype/Views/Entities/Today/LogTable/LogTable.swift
+++ b/DLPrototype/Views/Entities/Today/LogTable/LogTable.swift
@@ -200,7 +200,7 @@ extension Today.LogTable {
                         .background(Theme.headerColour)
 
                         if records.count > 0 {
-                            ForEach(grouped, id: \.id) {group in group}
+                            ForEach(grouped) {group in group}
                         } else {
                             LogRowEmpty(message: "No records found for date \(nav.session.date.formatted(date: .abbreviated, time: .omitted))", index: 0, colour: Theme.rowColour)
                         }

--- a/DLPrototype/Views/Entities/Today/Sidebars/TodaySidebar.swift
+++ b/DLPrototype/Views/Entities/Today/Sidebars/TodaySidebar.swift
@@ -33,7 +33,7 @@ extension TodaySidebar {
         tabs = [
             ToolbarButton(
                 id: 0,
-                helpText: "Find resources",
+                helpText: "Resources",
                 icon: "globe.americas",
                 labelText: "Resources",
                 contents: AnyView(JobsWidgetRedux())

--- a/DLPrototype/Views/Entities/Today/Sidebars/TodaySidebar.swift
+++ b/DLPrototype/Views/Entities/Today/Sidebars/TodaySidebar.swift
@@ -27,7 +27,6 @@ struct TodaySidebar: View {
             }
             Spacer()
         }
-        .padding()
         .onAppear(perform: createToolbar)
     }
 }
@@ -37,20 +36,27 @@ extension TodaySidebar {
         tabs = [
             ToolbarButton(
                 id: 0,
+                helpText: "Find resources",
+                icon: "globe.americas",
+                labelText: "Resources",
+                contents: AnyView(JobsWidgetRedux())
+            ),
+            ToolbarButton(
+                id: 1,
                 helpText: "Jobs",
                 icon: "hammer",
                 labelText: "Jobs",
                 contents: AnyView(JobPickerWidget())
             ),
             ToolbarButton(
-                id: 1,
+                id: 2,
                 helpText: "Tasks",
                 icon: "checklist",
                 labelText: "Tasks",
                 contents: AnyView(TasksWidget())
             ),
             ToolbarButton(
-                id: 2,
+                id: 3,
                 helpText: "Notes",
                 icon: "note.text",
                 labelText: "Notes",

--- a/DLPrototype/Views/Entities/Today/Sidebars/TodaySidebar.swift
+++ b/DLPrototype/Views/Entities/Today/Sidebars/TodaySidebar.swift
@@ -37,6 +37,13 @@ extension TodaySidebar {
                 icon: "globe.americas",
                 labelText: "Resources",
                 contents: AnyView(JobsWidgetRedux())
+            ),
+            ToolbarButton(
+                id: 1,
+                helpText: "Outline",
+                icon: "menucard",
+                labelText: "Outline",
+                contents: AnyView(OutlineWidget())
             )
         ]
     }

--- a/DLPrototype/Views/Entities/Today/Sidebars/TodaySidebar.swift
+++ b/DLPrototype/Views/Entities/Today/Sidebars/TodaySidebar.swift
@@ -37,27 +37,6 @@ extension TodaySidebar {
                 icon: "globe.americas",
                 labelText: "Resources",
                 contents: AnyView(JobsWidgetRedux())
-            ),
-            ToolbarButton(
-                id: 1,
-                helpText: "Jobs",
-                icon: "hammer",
-                labelText: "Jobs",
-                contents: AnyView(JobPickerWidget())
-            ),
-            ToolbarButton(
-                id: 2,
-                helpText: "Tasks",
-                icon: "checklist",
-                labelText: "Tasks",
-                contents: AnyView(TasksWidget())
-            ),
-            ToolbarButton(
-                id: 3,
-                helpText: "Notes",
-                icon: "note.text",
-                labelText: "Notes",
-                contents: AnyView(NotesWidget())
             )
         ]
     }

--- a/DLPrototype/Views/Entities/Today/Sidebars/TodaySidebar.swift
+++ b/DLPrototype/Views/Entities/Today/Sidebars/TodaySidebar.swift
@@ -16,16 +16,13 @@ struct TodaySidebar: View {
     @EnvironmentObject public var nav: Navigation
 
     var body: some View {
-        ScrollView(showsIndicators: false) {
-            VStack(alignment: .leading, spacing: 5) {
-                FancyGenericToolbar(
-                    buttons: tabs,
-                    standalone: true,
-                    location: .sidebar,
-                    mode: .compact
-                )
-            }
-            Spacer()
+        VStack(alignment: .leading, spacing: 5) {
+            FancyGenericToolbar(
+                buttons: tabs,
+                standalone: true,
+                location: .sidebar,
+                mode: .compact
+            )
         }
         .onAppear(perform: createToolbar)
     }

--- a/DLPrototype/Views/Find/Inspector/Inspector.swift
+++ b/DLPrototype/Views/Find/Inspector/Inspector.swift
@@ -21,6 +21,8 @@ public struct Inspector: View, Identifiable {
     private var person: Person? = nil
     private var note: Note? = nil
     private var task: LogTask? = nil
+    private var term: TaxonomyTerm?
+    private var definition: TaxonomyTermDefinitions?
 
     @EnvironmentObject public var nav: Navigation
 
@@ -55,6 +57,10 @@ public struct Inspector: View, Identifiable {
                 InspectingNote(item: note)
             } else if let task = task {
                 InspectingTask(item: task)
+            } else if let term = term {
+                InspectingTerm(item: term)
+            } else if let definition = definition {
+                InspectingDefinition(item: definition)
             } else {
                 Text("Unable to inspect this item")
             }
@@ -75,6 +81,8 @@ public struct Inspector: View, Identifiable {
         case let en as Person: self.person = en
         case let en as Note: self.note = en
         case let en as LogTask: self.task = en
+        case let en as TaxonomyTerm: self.term = en
+        case let en as TaxonomyTermDefinitions: self.definition = en
         default: print("[error] FindDashboard.Inspector Unknown entity type=\(self.entity)")
         }
     }
@@ -530,6 +538,112 @@ public struct Inspector: View, Identifiable {
                             )
                         }
                     }
+                }
+            }
+        }
+    }
+
+    struct InspectingTerm: View {
+        public var item: TaxonomyTerm
+
+        @EnvironmentObject public var nav: Navigation
+
+        var body: some View {
+            VStack(alignment: .leading, spacing: 10) {
+                HStack(alignment: .top, spacing: 10) {
+                    Image(systemName: "questionmark.square.fill").symbolRenderingMode(.hierarchical)
+                    Text("Type: Taxonomy term")
+                    Spacer()
+                }
+                .help("Type: Taxonomy term")
+                Divider()
+
+                if let date = item.created {
+                    HStack(alignment: .top, spacing: 10) {
+                        Image(systemName: "calendar.badge.plus").symbolRenderingMode(.hierarchical)
+                        Text(date.description)
+                        Spacer()
+                    }
+                    .help("Created: \(date.description)")
+                    Divider()
+                }
+
+                if let date = item.lastUpdate {
+                    HStack(alignment: .top, spacing: 10) {
+                        Image(systemName: "calendar.badge.clock").symbolRenderingMode(.hierarchical)
+                        Text(date.description)
+                        Spacer()
+                    }
+                    .help("Last update: \(date.description)")
+                    Divider()
+                }
+
+                Spacer()
+                HStack(alignment: .top, spacing: 10) {
+                    FancyButtonv2(
+                        text: "Open",
+                        action: {nav.session.search.cancel() ; nav.setInspector()},
+                        icon: "arrow.right.square.fill",
+                        showLabel: true,
+                        size: .link,
+                        type: .clear,
+                        redirect: AnyView(EmptyView()),
+                        pageType: .terms,
+                        sidebar: AnyView(DefinitionSidebar())
+                    )
+                }
+            }
+        }
+    }
+
+    struct InspectingDefinition: View {
+        public var item: TaxonomyTermDefinitions
+
+        @EnvironmentObject public var nav: Navigation
+
+        var body: some View {
+            VStack(alignment: .leading, spacing: 10) {
+                HStack(alignment: .top, spacing: 10) {
+                    Image(systemName: "questionmark.square.fill").symbolRenderingMode(.hierarchical)
+                    Text("Type: Taxonomy definition")
+                    Spacer()
+                }
+                .help("Type: Taxonomy definition")
+                Divider()
+
+                if let date = item.created {
+                    HStack(alignment: .top, spacing: 10) {
+                        Image(systemName: "calendar.badge.plus").symbolRenderingMode(.hierarchical)
+                        Text(date.description)
+                        Spacer()
+                    }
+                    .help("Created: \(date.description)")
+                    Divider()
+                }
+
+                if let date = item.lastUpdate {
+                    HStack(alignment: .top, spacing: 10) {
+                        Image(systemName: "calendar.badge.clock").symbolRenderingMode(.hierarchical)
+                        Text(date.description)
+                        Spacer()
+                    }
+                    .help("Last update: \(date.description)")
+                    Divider()
+                }
+
+                Spacer()
+                HStack(alignment: .top, spacing: 10) {
+                    FancyButtonv2(
+                        text: "Open",
+                        action: {nav.session.search.cancel() ; nav.setInspector()},
+                        icon: "arrow.right.square.fill",
+                        showLabel: true,
+                        size: .link,
+                        type: .clear,
+                        redirect: AnyView(DefinitionDetail(definition: item)),
+                        pageType: .terms,
+                        sidebar: AnyView(DefinitionSidebar())
+                    )
                 }
             }
         }

--- a/DLPrototype/Views/Find/Inspector/Inspector.swift
+++ b/DLPrototype/Views/Find/Inspector/Inspector.swift
@@ -239,15 +239,14 @@ public struct Inspector: View, Identifiable {
 
                 if let message = item.message {
                     HStack(alignment: .top, spacing: 10) {
-                        Image(systemName: "doc.text.fill").symbolRenderingMode(.hierarchical)
-                        Text("Full message:")
+                        Image(systemName: "tray").symbolRenderingMode(.hierarchical)
+                        Text("Message")
                         Spacer()
                     }
                     Divider()
                     Text(message)
-                        .padding(.leading, 25)
                         .contextMenu {
-                            Button("Copy") {
+                            Button("Copy to clipboard") {
                                 ClipboardHelper.copy(message)
                             }
                         }
@@ -578,6 +577,34 @@ public struct Inspector: View, Identifiable {
                     Divider()
                 }
 
+                if let name = item.name {
+                    HStack(alignment: .center) {
+                        Image(systemName: "list.bullet.rectangle").symbolRenderingMode(.hierarchical)
+                        FancyButtonv2(
+                            text: name,
+                            action: {nav.session.search.cancel() ; nav.setInspector()},
+                            showLabel: true,
+                            showIcon: false,
+                            size: .link,
+                            type: .clear,
+                            redirect: AnyView(TermsDashboard()),
+                            pageType: .terms,
+                            sidebar: AnyView(TermsDashboardSidebar())
+                        )
+                        .help("Term: \(name)")
+                    }
+                    Divider()
+                }
+
+                if let defs = item.definitions?.allObjects as? [TaxonomyTermDefinitions] {
+                    HStack(alignment: .top, spacing: 10) {
+                        Image(systemName: "list.bullet").symbolRenderingMode(.hierarchical)
+                        Text("\(defs.count(where: {$0.alive == true})) definition(s)")
+                        Spacer()
+                    }
+                    Divider()
+                }
+
                 Spacer()
                 HStack(alignment: .top, spacing: 10) {
                     FancyButtonv2(
@@ -587,7 +614,7 @@ public struct Inspector: View, Identifiable {
                         showLabel: true,
                         size: .link,
                         type: .clear,
-                        redirect: AnyView(EmptyView()),
+                        redirect: AnyView(TermsDashboard()),
                         pageType: .terms,
                         sidebar: AnyView(DefinitionSidebar())
                     )
@@ -628,6 +655,45 @@ public struct Inspector: View, Identifiable {
                         Spacer()
                     }
                     .help("Last update: \(date.description)")
+                    Divider()
+                }
+
+                if let term = self.item.term {
+                    HStack(alignment: .center) {
+                        Image(systemName: "list.bullet.rectangle").symbolRenderingMode(.hierarchical)
+                        FancyButtonv2(
+                            text: term.name ?? "Not Found",
+                            action: {nav.session.search.cancel() ; nav.setInspector()},
+                            showLabel: true,
+                            showIcon: false,
+                            size: .link,
+                            type: .clear,
+                            redirect: AnyView(TermsDashboard()),
+                            pageType: .terms,
+                            sidebar: AnyView(TermsDashboardSidebar())
+                        )
+                    }
+                    Divider()
+                }
+
+                if let definition = self.item.definition {
+                    HStack(alignment: .center) {
+                        Image(systemName: "list.bullet").symbolRenderingMode(.hierarchical)
+                        Text("Definition")
+                    }
+                    Divider()
+                    HStack(alignment: .top, spacing: 10) {
+                        Text(definition)
+                            .contextMenu {
+                                Button {
+                                    ClipboardHelper.copy(definition)
+                                } label: {
+                                    Text("Copy to clipboard")
+                                }
+                            }
+                        Spacer()
+                    }
+                    .help("Full definition text")
                     Divider()
                 }
 

--- a/DLPrototype/Views/Find/Suggestions/Suggestions.swift
+++ b/DLPrototype/Views/Find/Suggestions/Suggestions.swift
@@ -238,13 +238,13 @@ extension FindDashboard {
                 
                 if publishedOnly.wrappedValue {
                     req.predicate = NSPredicate(
-                        format: "alive = true && (name BEGINSWITH %@ || pid BEGINSWITH %@) && company.hidden == false",
+                        format: "alive = true && (name CONTAINS[cd] %@ || pid BEGINSWITH %@) && company.hidden == false",
                         _searchText.wrappedValue,
                         _searchText.wrappedValue
                     )
                 } else {
                     req.predicate = NSPredicate(
-                        format: "(name BEGINSWITH %@ || pid BEGINSWITH %@) && company.hidden == false",
+                        format: "(name CONTAINS[cd] %@ || pid BEGINSWITH %@) && company.hidden == false",
                         _searchText.wrappedValue,
                         _searchText.wrappedValue
                     )
@@ -891,6 +891,7 @@ extension FindDashboard.Suggestions.SuggestedJobs {
 
     private func appear() -> Void {
         if items.count <= 5 {
+            self.showAll = true
             showChildren = true
         }
     }
@@ -903,6 +904,7 @@ extension FindDashboard.Suggestions.SuggestedProjects {
 
     private func appear() -> Void {
         if items.count <= 5 {
+            self.showAll = true
             showChildren = true
         }
     }
@@ -938,6 +940,7 @@ extension FindDashboard.Suggestions.SuggestedNotes {
 
     private func appear() -> Void {
         if items.count <= 5 {
+            self.showAll = true
             showChildren = true
         }
     }
@@ -950,6 +953,7 @@ extension FindDashboard.Suggestions.SuggestedTasks {
 
     private func appear() -> Void {
         if items.count <= 5 {
+            self.showAll = true
             showChildren = true
         }
     }
@@ -962,6 +966,7 @@ extension FindDashboard.Suggestions.SuggestedCompanies {
 
     private func appear() -> Void {
         if items.count <= 5 {
+            self.showAll = true
             showChildren = true
         }
     }
@@ -974,6 +979,7 @@ extension FindDashboard.Suggestions.SuggestedPeople {
 
     private func appear() -> Void {
         if items.count <= 5 {
+            self.showAll = true
             showChildren = true
         }
     }
@@ -986,6 +992,7 @@ extension FindDashboard.Suggestions.SuggestedRecords {
 
     private func appear() -> Void {
         if items.count <= 5 {
+            self.showAll = true
             showChildren = true
         }
     }
@@ -998,6 +1005,7 @@ extension FindDashboard.Suggestions.SuggestedTerms {
 
     private func appear() -> Void {
         if items.count <= 5 {
+            self.showAll = true
             showChildren = true
         }
     }
@@ -1010,6 +1018,7 @@ extension FindDashboard.Suggestions.SuggestedDefinitions {
 
     private func appear() -> Void {
         if items.count <= 5 {
+            self.showAll = true
             showChildren = true
         }
     }

--- a/DLPrototype/Views/Find/Suggestions/Suggestions.swift
+++ b/DLPrototype/Views/Find/Suggestions/Suggestions.swift
@@ -19,6 +19,8 @@ extension FindDashboard {
         @Binding public var showJobs: Bool
         @Binding public var showCompanies: Bool
         @Binding public var showPeople: Bool
+        @Binding public var showTerms: Bool
+        @Binding public var showDefinitions: Bool
         public var location: WidgetLocation
 
         @AppStorage("CreateEntitiesWidget.isSearching") private var isSearching: Bool = false
@@ -41,13 +43,15 @@ extension FindDashboard {
                             }
 
                             // @TODO: reduce this with a loop, each view is basically identical...
-                            if showJobs {SuggestedJobs(searchText: $searchText, publishedOnly: $publishedOnly)}
-                            if showProjects {SuggestedProjects(searchText: $searchText, publishedOnly: $publishedOnly)}
+                            if showRecords {SuggestedRecords(searchText: $searchText, publishedOnly: $publishedOnly)}
                             if showNotes {SuggestedNotes(searchText: $searchText, publishedOnly: $publishedOnly)}
                             if showTasks {SuggestedTasks(searchText: $searchText)}
-                            if showRecords {SuggestedRecords(searchText: $searchText, publishedOnly: $publishedOnly)}
+                            if showProjects {SuggestedProjects(searchText: $searchText, publishedOnly: $publishedOnly)}
+                            if showJobs {SuggestedJobs(searchText: $searchText, publishedOnly: $publishedOnly)}
                             if showCompanies {SuggestedCompanies(searchText: $searchText, publishedOnly: $publishedOnly)}
                             if showPeople {SuggestedPeople(searchText: $searchText)}
+                            if showTerms {SuggestedTerms(searchText: $searchText, publishedOnly: $publishedOnly)}
+                            if showDefinitions {SuggestedDefinitions(searchText: $searchText, publishedOnly: $publishedOnly)}
                         }
                     }
                     .padding()
@@ -61,24 +65,25 @@ extension FindDashboard {
         }
         
         struct SuggestedJobs: View {
+            @EnvironmentObject public var nav: Navigation
             @Binding public var searchText: String
             @Binding public var publishedOnly: Bool
             @State private var showChildren: Bool = false
+            @State private var showAll: Bool = false
             @State private var hover: Bool = false
             @FetchRequest private var items: FetchedResults<Job>
-            
-            @EnvironmentObject public var nav: Navigation
             
             var body: some View {
                 if items.count > 0 {
                     VStack(alignment: .leading) {
                         Button {
                             showChildren.toggle()
+                            self.showAll.toggle()
                         } label: {
                             ZStack {
                                 Theme.base
                                 HStack(spacing: 1) {
-                                    Text("Showing \(items.prefix(5).count)/\(items.count) Jobs")
+                                    Text(self.showAll ? "Showing \(items.count) Jobs" : "Showing \(items.prefix(5).count)/\(items.count) Jobs")
                                         .font(Theme.fontSubTitle)
                                     Spacer()
                                     Image(systemName: showChildren ? "minus.square.fill" : "plus.square.fill").symbolRenderingMode(.hierarchical)
@@ -93,12 +98,12 @@ extension FindDashboard {
                         
                         if showChildren {
                             VStack(alignment: .leading) {
-                                ForEach(items.prefix(5), id: \.objectID) { item in
+                                ForEach(items.prefix(self.showAll ? items.count : 5), id: \.objectID) { item in
                                     VStack(alignment: .leading, spacing: 10) {
                                         Divider()
                                         HStack {
                                             FancyButtonv2(
-                                                text: item.jid.string,
+                                                text: item.title ?? item.jid.string,
                                                 action: {choose(item)},
                                                 icon: "questionmark.square.fill",
                                                 showIcon: true,
@@ -108,7 +113,7 @@ extension FindDashboard {
                                             .help("Inspect")
                                             Spacer()
                                             FancyButtonv2(
-                                                text: item.jid.string,
+                                                text: item.title ?? item.jid.string,
                                                 action: {setContext(item)},
                                                 icon: "arrow.right.square.fill",
                                                 showLabel: false,
@@ -161,24 +166,25 @@ extension FindDashboard {
         }
         
         struct SuggestedProjects: View {
+            @EnvironmentObject public var nav: Navigation
             @Binding public var searchText: String
             @Binding public var publishedOnly: Bool
             @State private var showChildren: Bool = false
+            @State private var showAll: Bool = false
             @State private var hover: Bool = false
             @FetchRequest private var items: FetchedResults<Project>
-            
-            @EnvironmentObject public var nav: Navigation
 
             var body: some View {
                 if items.count > 0 {
                     VStack {
                         Button {
                             showChildren.toggle()
+                            self.showAll.toggle()
                         } label: {
                             ZStack {
                                 Theme.base
                                 HStack(spacing: 1) {
-                                    Text("Showing \(items.prefix(5).count)/\(items.count) Projects")
+                                    Text(self.showAll ? "Showing \(items.count) Projects" : "Showing \(items.prefix(5).count)/\(items.count) Projects")
                                         .font(Theme.fontSubTitle)
                                     Spacer()
                                     Image(systemName: showChildren ? "minus.square.fill" : "plus.square.fill").symbolRenderingMode(.hierarchical)
@@ -193,7 +199,7 @@ extension FindDashboard {
 
                         if showChildren {
                             VStack(alignment: .leading, spacing: 0) {
-                                ForEach(items.prefix(5), id: \.objectID) { item in
+                                ForEach(items.prefix(self.showAll ? items.count : 5), id: \.objectID) { item in
                                     VStack {
                                         Divider()
                                         HStack {
@@ -249,24 +255,25 @@ extension FindDashboard {
         }
         
         struct SuggestedNotes: View {
+            @EnvironmentObject public var nav: Navigation
             @Binding public var searchText: String
             @Binding public var publishedOnly: Bool
             @State private var showChildren: Bool = false
+            @State private var showAll: Bool = false
             @State private var hover: Bool = false
             @FetchRequest private var items: FetchedResults<Note>
-            
-            @EnvironmentObject public var nav: Navigation
 
             var body: some View {
                 if items.count > 0 {
                     VStack {
                         Button {
                             showChildren.toggle()
+                            self.showAll.toggle()
                         } label: {
                             ZStack {
                                 Theme.base
                                 HStack(spacing: 1) {
-                                    Text("Showing \(items.prefix(5).count)/\(items.count) Notes")
+                                    Text(self.showAll ? "Showing \(items.count) Notes" : "Showing \(items.prefix(5).count)/\(items.count) Notes")
                                         .font(Theme.fontSubTitle)
                                     Spacer()
                                     Image(systemName: showChildren ? "minus.square.fill" : "plus.square.fill").symbolRenderingMode(.hierarchical)
@@ -281,7 +288,7 @@ extension FindDashboard {
                         
                         if showChildren {
                             VStack(alignment: .leading, spacing: 0) {
-                                ForEach(items.prefix(5), id: \.objectID) { item in
+                                ForEach(items.prefix(self.showAll ? items.count : 5), id: \.objectID) { item in
                                     VStack {
                                         Divider()
                                         HStack {
@@ -347,23 +354,24 @@ extension FindDashboard {
         }
         
         struct SuggestedTasks: View {
+            @EnvironmentObject public var nav: Navigation
             @Binding public var searchText: String
             @State private var showChildren: Bool = false
+            @State private var showAll: Bool = false
             @State private var hover: Bool = false
             @FetchRequest private var items: FetchedResults<LogTask>
-            
-            @EnvironmentObject public var nav: Navigation
 
             var body: some View {
                 if items.count > 0 {
                     VStack {
                         Button {
                             showChildren.toggle()
+                            self.showAll.toggle()
                         } label: {
                             ZStack {
                                 Theme.base
                                 HStack(spacing: 1) {
-                                    Text("Showing \(items.prefix(5).count)/\(items.count) Tasks")
+                                    Text(self.showAll ? "Showing \(items.count) Tasks" : "Showing \(items.prefix(5).count)/\(items.count) Tasks")
                                         .font(Theme.fontSubTitle)
                                     Spacer()
                                     Image(systemName: showChildren ? "minus.square.fill" : "plus.square.fill").symbolRenderingMode(.hierarchical)
@@ -378,7 +386,7 @@ extension FindDashboard {
 
                         if showChildren {
                             VStack(alignment: .leading, spacing: 0) {
-                                ForEach(items.prefix(5), id: \.objectID) { item in
+                                ForEach(items.prefix(self.showAll ? items.count : 5), id: \.objectID) { item in
                                     VStack {
                                         Divider()
                                         HStack {
@@ -424,14 +432,13 @@ extension FindDashboard {
         }
         
         struct SuggestedRecords: View {
+            @EnvironmentObject public var nav: Navigation
             @Binding public var searchText: String
             @Binding public var publishedOnly: Bool
             @State private var showChildren: Bool = false
-            @State private var hover: Bool = false
             @State private var showAll: Bool = false
+            @State private var hover: Bool = false
             @FetchRequest private var items: FetchedResults<LogRecord>
-            
-            @EnvironmentObject public var nav: Navigation
 
             var body: some View {
                 if items.count > 0 {
@@ -512,24 +519,25 @@ extension FindDashboard {
         }
         
         struct SuggestedCompanies: View {
+            @EnvironmentObject public var nav: Navigation
             @Binding public var searchText: String
             @Binding public var publishedOnly: Bool
             @State private var showChildren: Bool = false
+            @State private var showAll: Bool = false
             @State private var hover: Bool = false
             @FetchRequest private var items: FetchedResults<Company>
-            
-            @EnvironmentObject public var nav: Navigation
 
             var body: some View {
                 if items.count > 0 {
                     VStack {
                         Button {
                             showChildren.toggle()
+                            self.showAll.toggle()
                         } label: {
                             ZStack {
                                 Theme.base
                                 HStack(spacing: 1) {
-                                    Text("Showing \(items.prefix(5).count)/\(items.count) Companies")
+                                    Text(self.showAll ? "Showing \(items.count) Companies" : "Showing \(items.prefix(5).count)/\(items.count) Companies")
                                         .font(Theme.fontSubTitle)
                                     Spacer()
                                     Image(systemName: showChildren ? "minus.square.fill" : "plus.square.fill").symbolRenderingMode(.hierarchical)
@@ -598,23 +606,24 @@ extension FindDashboard {
         }
         
         struct SuggestedPeople: View {
+            @EnvironmentObject public var nav: Navigation
             @Binding public var searchText: String
             @State private var showChildren: Bool = false
+            @State private var showAll: Bool = false
             @State private var hover: Bool = false
             @FetchRequest private var items: FetchedResults<Person>
-            
-            @EnvironmentObject public var nav: Navigation
 
             var body: some View {
                 if items.count > 0 {
                     VStack {
                         Button {
                             showChildren.toggle()
+                            self.showAll.toggle()
                         } label: {
                             ZStack {
                                 Theme.base
                                 HStack(spacing: 1) {
-                                    Text("Showing \(items.prefix(5).count)/\(items.count) People")
+                                    Text(self.showAll ? "Showing \(items.count) People" : "Showing \(items.prefix(5).count)/\(items.count) People")
                                         .font(Theme.fontSubTitle)
                                     Spacer()
                                     Image(systemName: showChildren ? "minus.square.fill" : "plus.square.fill").symbolRenderingMode(.hierarchical)
@@ -629,7 +638,7 @@ extension FindDashboard {
 
                         if showChildren {
                             VStack(alignment: .leading, spacing: 0) {
-                                ForEach(items.prefix(5), id: \.objectID) { item in
+                                ForEach(items.prefix(self.showAll ? items.count : 5), id: \.objectID) { item in
                                     VStack {
                                         Divider()
                                         HStack {
@@ -669,6 +678,180 @@ extension FindDashboard {
                     _searchText.wrappedValue
                 )
                 
+                _items = FetchRequest(fetchRequest: req, animation: .easeInOut)
+            }
+        }
+
+        struct SuggestedTerms: View {
+            @EnvironmentObject public var nav: Navigation
+            @Binding public var searchText: String
+            @Binding public var publishedOnly: Bool
+            @State private var showChildren: Bool = false
+            @State private var showAll: Bool = false
+            @State private var hover: Bool = false
+            @FetchRequest private var items: FetchedResults<TaxonomyTerm>
+
+            var body: some View {
+                if items.count > 0 {
+                    VStack {
+                        Button {
+                            showChildren.toggle()
+                            self.showAll.toggle()
+                        } label: {
+                            ZStack {
+                                Theme.base
+                                HStack(spacing: 1) {
+                                    Text(self.showAll ? "Showing \(items.count) Terms" : "Showing \(items.prefix(5).count)/\(items.count) Terms")
+                                        .font(Theme.fontSubTitle)
+                                    Spacer()
+                                    Image(systemName: showChildren ? "minus.square.fill" : "plus.square.fill").symbolRenderingMode(.hierarchical)
+                                        .font(.title2)
+                                }
+                                .padding()
+                                .background(hover ? Theme.rowColour : Theme.subHeaderColour)
+                            }
+                        }
+                        .buttonStyle(.plain)
+                        .useDefaultHover({inside in hover = inside})
+
+                        if showChildren {
+                            VStack(alignment: .leading, spacing: 0) {
+                                ForEach(items.prefix(self.showAll ? items.count : 5), id: \.objectID) { item in
+                                    VStack {
+                                        Divider()
+                                        HStack {
+                                            FancyButtonv2(
+                                                text: item.name ?? "",
+                                                action: {choose(item)},
+                                                icon: "questionmark.square.fill",
+                                                fgColour: .white,
+                                                showIcon: true,
+                                                size: .link,
+                                                type: .clear
+                                            )
+                                            .help("Inspect")
+                                            Spacer()
+                                        }
+                                    }
+                                    .padding(.bottom, 10)
+                                }
+                            }
+                        }
+                    }
+                    .onAppear(perform: appear)
+                } else {
+                    EmptyView()
+                }
+            }
+
+            init(searchText: Binding<String>, publishedOnly: Binding<Bool>) {
+                _searchText = searchText
+                _publishedOnly = publishedOnly
+
+                let req: NSFetchRequest<TaxonomyTerm> = TaxonomyTerm.fetchRequest()
+                req.sortDescriptors = [
+                    NSSortDescriptor(keyPath: \TaxonomyTerm.name, ascending: true),
+                ]
+
+                if publishedOnly.wrappedValue {
+                    req.predicate = NSPredicate(
+                        format: "alive == true && name CONTAINS[cd] %@",
+                        _searchText.wrappedValue
+                    )
+                } else {
+                    req.predicate = NSPredicate(
+                        format: "name CONTAINS[cd] %@",
+                        _searchText.wrappedValue
+                    )
+                }
+
+                _items = FetchRequest(fetchRequest: req, animation: .easeInOut)
+            }
+        }
+
+        struct SuggestedDefinitions: View {
+            @EnvironmentObject public var nav: Navigation
+            @Binding public var searchText: String
+            @Binding public var publishedOnly: Bool
+            @State private var showChildren: Bool = false
+            @State private var showAll: Bool = false
+            @State private var hover: Bool = false
+            @FetchRequest private var items: FetchedResults<TaxonomyTermDefinitions>
+
+            var body: some View {
+                if items.count > 0 {
+                    VStack {
+                        Button {
+                            showChildren.toggle()
+                            self.showAll.toggle()
+                        } label: {
+                            ZStack {
+                                Theme.base
+                                HStack(spacing: 1) {
+                                    Text(self.showAll ? "Showing \(items.count) Definitions" : "Showing \(items.prefix(5).count)/\(items.count) Definitions")
+                                        .font(Theme.fontSubTitle)
+                                    Spacer()
+                                    Image(systemName: showChildren ? "minus.square.fill" : "plus.square.fill").symbolRenderingMode(.hierarchical)
+                                        .font(.title2)
+                                }
+                                .padding()
+                                .background(hover ? Theme.rowColour : Theme.subHeaderColour)
+                            }
+                        }
+                        .buttonStyle(.plain)
+                        .useDefaultHover({inside in hover = inside})
+
+                        if showChildren {
+                            VStack(alignment: .leading, spacing: 0) {
+                                ForEach(items.prefix(self.showAll ? items.count : 5), id: \.objectID) { item in
+                                    VStack {
+                                        Divider()
+                                        HStack {
+                                            FancyButtonv2(
+                                                text: item.definition ?? "",
+                                                action: {choose(item)},
+                                                icon: "questionmark.square.fill",
+                                                fgColour: .white,
+                                                showIcon: true,
+                                                size: .link,
+                                                type: .clear
+                                            )
+                                            .help("Inspect")
+                                            Spacer()
+                                        }
+                                    }
+                                    .padding(.bottom, 10)
+                                }
+                            }
+                        }
+                    }
+                    .onAppear(perform: appear)
+                } else {
+                    EmptyView()
+                }
+            }
+
+            init(searchText: Binding<String>, publishedOnly: Binding<Bool>) {
+                _searchText = searchText
+                _publishedOnly = publishedOnly
+
+                let req: NSFetchRequest<TaxonomyTermDefinitions> = TaxonomyTermDefinitions.fetchRequest()
+                req.sortDescriptors = [
+                    NSSortDescriptor(keyPath: \TaxonomyTermDefinitions.created, ascending: true),
+                ]
+
+                if publishedOnly.wrappedValue {
+                    req.predicate = NSPredicate(
+                        format: "alive = true && definition CONTAINS[cd] %@",
+                        _searchText.wrappedValue
+                    )
+                } else {
+                    req.predicate = NSPredicate(
+                        format: "definition CONTAINS[cd] %@",
+                        _searchText.wrappedValue
+                    )
+                }
+
                 _items = FetchRequest(fetchRequest: req, animation: .easeInOut)
             }
         }
@@ -798,6 +981,30 @@ extension FindDashboard.Suggestions.SuggestedPeople {
 
 extension FindDashboard.Suggestions.SuggestedRecords {
     private func choose(_ item: LogRecord) -> Void {
+        nav.session.search.inspect(item)
+    }
+
+    private func appear() -> Void {
+        if items.count <= 5 {
+            showChildren = true
+        }
+    }
+}
+
+extension FindDashboard.Suggestions.SuggestedTerms {
+    private func choose(_ item: TaxonomyTerm) -> Void {
+        nav.session.search.inspect(item)
+    }
+
+    private func appear() -> Void {
+        if items.count <= 5 {
+            showChildren = true
+        }
+    }
+}
+
+extension FindDashboard.Suggestions.SuggestedDefinitions {
+    private func choose(_ item: TaxonomyTermDefinitions) -> Void {
         nav.session.search.inspect(item)
     }
 

--- a/DLPrototype/Views/Planning/Sidebars/DefaultPlanningSidebar.swift
+++ b/DLPrototype/Views/Planning/Sidebars/DefaultPlanningSidebar.swift
@@ -18,6 +18,5 @@ struct DefaultPlanningSidebar: View {
             }
             Spacer()
         }
-        .padding()
     }
 }

--- a/DLPrototype/Views/Shared/AppSidebar/SidebarButton.swift
+++ b/DLPrototype/Views/Shared/AppSidebar/SidebarButton.swift
@@ -84,7 +84,9 @@ struct SidebarButton: View, Identifiable {
                 }
             case .companies:
                 HStack(alignment: .top, spacing: 0) {
-                    ActiveIndicator(colour: nav.session.job?.project?.company?.backgroundColor ?? .clear, href: .companies)
+                    if let colour = nav.session.job?.project?.company?.backgroundColor {
+                        ActiveIndicator(colour: colour, href: .companies)
+                    }
                     button.frame(width: 50, height: 50)
                 }
             default: button.frame(width: 50, height: 50)

--- a/DLPrototype/Views/Shared/AppSidebar/SidebarButton.swift
+++ b/DLPrototype/Views/Shared/AppSidebar/SidebarButton.swift
@@ -81,6 +81,8 @@ struct SidebarButton: View, Identifiable {
                                 }
                             }
                         }
+//                        .foregroundStyle(nav.session.job != nil ? nav.session.job!.backgroundColor : isDatePickerPresented && nav.parent == pageType ? .black : highlighted ? .white : .white.opacity(0.8))
+                        .foregroundStyle(isDatePickerPresented && nav.parent == pageType ? .black : highlighted ? .white : .white.opacity(0.8))
                 }
             case .companies:
                 HStack(alignment: .top, spacing: 0) {
@@ -88,6 +90,8 @@ struct SidebarButton: View, Identifiable {
                         ActiveIndicator(colour: colour, href: .companies)
                     }
                     button.frame(width: 50, height: 50)
+//                        .foregroundStyle(nav.session.job != nil ? nav.session.job!.backgroundColor : isDatePickerPresented && nav.parent == pageType ? .black : highlighted ? .white : .white.opacity(0.8))
+                        .foregroundStyle(isDatePickerPresented && nav.parent == pageType ? .black : highlighted ? .white : .white.opacity(0.8))
                 }
             default: button.frame(width: 50, height: 50)
             }
@@ -127,7 +131,6 @@ struct SidebarButton: View, Identifiable {
                 Image(systemName: isDatePickerPresented && nav.parent == pageType ? "xmark" : (altMode != nil ? (altMode!.condition ? altMode!.icon : icon) : icon))
                    .font(.title)
                    .symbolRenderingMode(.hierarchical)
-                   .foregroundColor(isDatePickerPresented && nav.parent == pageType ? .black : highlighted ? .white : .white.opacity(0.8))
 
             }
         }
@@ -170,7 +173,6 @@ struct SidebarButton: View, Identifiable {
                 Image(systemName: isDatePickerPresented && nav.parent == pageType ? "xmark" : (altMode != nil ? (altMode!.condition ? altMode!.icon : icon) : icon))
                    .font(.title)
                    .symbolRenderingMode(.hierarchical)
-                   .foregroundColor(isDatePickerPresented && nav.parent == pageType ? .black : highlighted ? .white : .white.opacity(0.8))
 
             }
         })

--- a/DLPrototype/Views/Shared/AppSidebar/Widgets/CreateEntitiesWidget.swift
+++ b/DLPrototype/Views/Shared/AppSidebar/Widgets/CreateEntitiesWidget.swift
@@ -221,7 +221,7 @@ struct CreateEntitiesWidget: View {
             VStack(alignment: .leading) {
                 HStack(alignment: .top, spacing: 5) {
                     FancyButtonv2(
-                        text: "New company",
+                        text: "Company",
                         action: {isCreateStackShowing = false; isSearchStackShowing = false},
                         icon: "building.2",
                         fgColour: .white,
@@ -236,7 +236,7 @@ struct CreateEntitiesWidget: View {
 
                 ZStack(alignment: .topLeading) {
                     HStack(alignment: .center) {
-                        Divider().frame(height: 121)
+                        Divider().frame(height: 149)
                     }
                     VStack(alignment: .leading) {
                         HStack(alignment: .center, spacing: 0) {
@@ -246,9 +246,9 @@ struct CreateEntitiesWidget: View {
 
                             HStack {
                                 FancyButtonv2(
-                                    text: "New project",
+                                    text: "Project",
                                     action: {isCreateStackShowing = false; isSearchStackShowing = false},
-                                    icon: "folder.badge.plus",
+                                    icon: "folder",
                                     fgColour: .white,
                                     size: .link,
                                     type: nav.parent == .projects ? .secondary : .standard,
@@ -266,7 +266,7 @@ struct CreateEntitiesWidget: View {
                             }
                             HStack {
                                 FancyButtonv2(
-                                    text: "New job",
+                                    text: "Job",
                                     action: {isCreateStackShowing = false; isSearchStackShowing = false},
                                     icon: "hammer",
                                     fgColour: .white,
@@ -286,9 +286,9 @@ struct CreateEntitiesWidget: View {
                             }
                             HStack {
                                 FancyButtonv2(
-                                    text: "New note",
+                                    text: "Note",
                                     action: {isCreateStackShowing = false; isSearchStackShowing = false},
-                                    icon: "note.text.badge.plus",
+                                    icon: "note.text",
                                     fgColour: .white,
                                     size: .link,
                                     type: nav.parent == .notes ? .secondary : .standard,
@@ -306,7 +306,7 @@ struct CreateEntitiesWidget: View {
                             }
                             HStack {
                                 FancyButtonv2(
-                                    text: "New task",
+                                    text: "Task",
                                     action: {isCreateStackShowing = false; isSearchStackShowing = false},
                                     icon: "checklist.checked",
                                     fgColour: .white,
@@ -326,15 +326,35 @@ struct CreateEntitiesWidget: View {
                             }
                             HStack {
                                 FancyButtonv2(
-                                    text: "New Record",
+                                    text: "Record",
                                     action: {isCreateStackShowing = false; isSearchStackShowing = false},
-                                    icon: "doc.append",
+                                    icon: "tray",
                                     fgColour: .white,
                                     size: .link,
                                     type: nav.parent == .tasks ? .secondary : .standard,
                                     redirect: AnyView(Today()),
                                     pageType: .today,
                                     sidebar: AnyView(TodaySidebar())
+                                )
+                            }
+                            Spacer()
+                        }
+
+                        HStack(alignment: .center, spacing: 0) {
+                            VStack(alignment: .center) {
+                                Divider().frame(width: 60)
+                            }
+                            HStack {
+                                FancyButtonv2(
+                                    text: "Definition",
+                                    action: {isCreateStackShowing = false; isSearchStackShowing = false},
+                                    icon: "list.bullet.rectangle",
+                                    fgColour: .white,
+                                    size: .link,
+                                    type: nav.parent == .tasks ? .secondary : .standard,
+                                    redirect: AnyView(TermsDashboard()),
+                                    pageType: .terms,
+                                    sidebar: AnyView(TermsDashboardSidebar())
                                 )
                             }
                             Spacer()

--- a/DLPrototype/Views/Shared/AppSidebar/Widgets/DateSelectorWidget.swift
+++ b/DLPrototype/Views/Shared/AppSidebar/Widgets/DateSelectorWidget.swift
@@ -78,7 +78,7 @@ struct DateSelectorWidget: View {
                 VStack(alignment: .leading, spacing: 0) {
                     ScrollView(showsIndicators: false) {
                         VStack(alignment: .leading, spacing: 0) {
-                            ForEach(days, id: \.id) { day in
+                            ForEach(days) { day in
                                 DateSelectorRow(
                                     day: day,
                                     callback: actionOnChangeDate,

--- a/DLPrototype/Views/Shared/AppSidebar/Widgets/JobsWidget.swift
+++ b/DLPrototype/Views/Shared/AppSidebar/Widgets/JobsWidget.swift
@@ -241,6 +241,11 @@ struct UnifiedSidebar {
                                         Definitions(job: self.job, definitions: definitions)
                                     }
                                 }
+                                if let records = self.job.records?.allObjects as? [LogRecord] {
+                                    if records.count > 0 {
+                                        Records(job: self.job, records: records)
+                                    }
+                                }
                             }
                             .padding(.leading, 15)
                         }
@@ -261,21 +266,18 @@ struct UnifiedSidebar {
 
         var body: some View {
             VStack(alignment: .leading, spacing: 0) {
-                EntityRowButton(text: "\(self.tasks.count) Tasks", isPresented: $isPresented)
-                    .useDefaultHover({ inside in self.highlighted = inside})
+                ZStack(alignment: .trailing) {
+                    EntityRowButton(text: "\(self.tasks.count) Tasks", isPresented: $isPresented)
+                        .useDefaultHover({ inside in self.highlighted = inside})
+                    RowAddNavLink(
+                        title: "Add",
+                        target: AnyView(EmptyView())
+                    )
+                    .buttonStyle(.plain)
+                }
+                .background(Theme.base.opacity(0.6).blendMode(.softLight))
 
                 if self.isPresented {
-                    HStack(alignment: .center, spacing: 0) {
-                        Spacer()
-                        RowAddNavLink(
-                            title: "+ Task",
-                            target: AnyView(EmptyView())
-                        )
-                        .buttonStyle(.plain)
-                    }
-                    .padding([.top, .bottom], 8)
-                    .background(Theme.base.opacity(0.6).blendMode(.softLight))
-
                     VStack(alignment: .leading, spacing: 0) {
                         ZStack(alignment: .topLeading) {
                             LinearGradient(colors: [Theme.base, .clear], startPoint: .top, endPoint: .bottom)
@@ -313,21 +315,18 @@ struct UnifiedSidebar {
 
         var body: some View {
             VStack(alignment: .leading, spacing: 0) {
-                EntityRowButton(text: "\(self.notes.count) Notes", isPresented: $isPresented)
-                    .useDefaultHover({ inside in self.highlighted = inside})
+                ZStack(alignment: .trailing) {
+                    EntityRowButton(text: "\(self.notes.count) Notes", isPresented: $isPresented)
+                        .useDefaultHover({ inside in self.highlighted = inside})
+                    RowAddNavLink(
+                        title: "Add",
+                        target: AnyView(EmptyView())
+                    )
+                    .buttonStyle(.plain)
+                }
+                .background(Theme.base.opacity(0.6).blendMode(.softLight))
 
                 if self.isPresented {
-                    HStack(alignment: .center, spacing: 0) {
-                        Spacer()
-                        RowAddNavLink(
-                            title: "+ Note",
-                            target: AnyView(EmptyView())
-                        )
-                        .buttonStyle(.plain)
-                    }
-                    .padding([.top, .bottom], 8)
-                    .background(Theme.base.opacity(0.6).blendMode(.softLight))
-
                     VStack(alignment: .leading, spacing: 0) {
                         ZStack(alignment: .topLeading) {
                             LinearGradient(colors: [Theme.base, .clear], startPoint: .top, endPoint: .bottom)
@@ -365,21 +364,18 @@ struct UnifiedSidebar {
 
         var body: some View {
             VStack(alignment: .leading, spacing: 0) {
-                EntityRowButton(text: "\(self.definitions.count) Definitions", isPresented: $isPresented)
-                    .useDefaultHover({ inside in self.highlighted = inside})
+                ZStack(alignment: .trailing) {
+                    EntityRowButton(text: "\(self.definitions.count) Definitions", isPresented: $isPresented)
+                        .useDefaultHover({ inside in self.highlighted = inside})
+                    RowAddNavLink(
+                        title: "Add",
+                        target: AnyView(EmptyView())
+                    )
+                    .buttonStyle(.plain)
+                }
+                .background(Theme.base.opacity(0.6).blendMode(.softLight))
 
                 if self.isPresented {
-                    HStack(alignment: .center, spacing: 0) {
-                        Spacer()
-                        RowAddNavLink(
-                            title: "+ Definition",
-                            target: AnyView(EmptyView())
-                        )
-                        .buttonStyle(.plain)
-                    }
-                    .padding([.top, .bottom], 8)
-                    .background(Theme.base.opacity(0.6).blendMode(.softLight))
-
                     VStack(alignment: .leading, spacing: 0) {
                         ZStack(alignment: .topLeading) {
                             LinearGradient(colors: [Theme.base, .clear], startPoint: .top, endPoint: .bottom)
@@ -408,6 +404,55 @@ struct UnifiedSidebar {
         }
     }
 
+    struct Records: View {
+        @EnvironmentObject private var state: Navigation
+        public let job: Job
+        public let records: [LogRecord]
+        @State private var isPresented: Bool = false
+        @State private var highlighted: Bool = false
+
+        var body: some View {
+            VStack(alignment: .leading, spacing: 0) {
+                ZStack(alignment: .trailing) {
+                    EntityRowButton(text: "\(self.records.count) Records", isPresented: $isPresented)
+                        .useDefaultHover({ inside in self.highlighted = inside})
+                    RowAddNavLink(
+                        title: "Add",
+                        target: AnyView(EmptyView())
+                    )
+                    .buttonStyle(.plain)
+                }
+                .background(Theme.base.opacity(0.6).blendMode(.softLight))
+
+                if self.isPresented {
+                    VStack(alignment: .leading, spacing: 0) {
+                        ZStack(alignment: .topLeading) {
+                            LinearGradient(colors: [Theme.base, .clear], startPoint: .top, endPoint: .bottom)
+                                .opacity(0.6)
+                                .blendMode(.softLight)
+                                .frame(height: 50)
+                            VStack(alignment: .leading, spacing: 0) {
+                                ForEach(self.records, id: \.objectID) { record in
+                                    if record.message != nil {
+                                        Button {
+//                                            self.state.to(.taskDetail)
+                                        } label: {
+                                            Text(record.message!)
+                                        }
+                                        .buttonStyle(.plain)
+                                    }
+                                }
+                            }
+                            .padding(.leading, 15)
+                        }
+                    }
+                }
+            }
+            .background(self.job.alive ? self.highlighted ? self.job.backgroundColor.opacity(0.9) : self.job.backgroundColor : .gray.opacity(0.8))
+            .foregroundStyle((self.job.alive ? self.job.backgroundColor : .gray).isBright() ? Theme.base : .white)
+        }
+    }
+
     struct People: View {
         @EnvironmentObject private var state: Navigation
         public let entity: Company
@@ -416,21 +461,18 @@ struct UnifiedSidebar {
 
         var body: some View {
             VStack(alignment: .leading, spacing: 0) {
-                RowButton(text: "People", alive: self.entity.alive, isPresented: $isPresented)
-                    .useDefaultHover({ inside in self.highlighted = inside})
+                ZStack(alignment: .trailing) {
+                    EntityRowButton(text: "People", isPresented: $isPresented)
+                        .useDefaultHover({ inside in self.highlighted = inside})
+                    RowAddNavLink(
+                        title: "Add",
+                        target: AnyView(EmptyView())
+                    )
+                    .buttonStyle(.plain)
+                }
+                .background(Theme.base.opacity(0.6).blendMode(.softLight))
 
                 if self.isPresented {
-                    HStack(alignment: .center, spacing: 0) {
-                        Spacer()
-                        RowAddNavLink(
-                            title: "+ Task",
-                            target: AnyView(EmptyView())
-                        )
-                        .buttonStyle(.plain)
-                    }
-                    .padding([.top, .bottom], 8)
-                    .background(Theme.base.opacity(0.6).blendMode(.softLight))
-
                     VStack(alignment: .leading, spacing: 0) {
                         ZStack(alignment: .topLeading) {
                             LinearGradient(colors: [Theme.base, .clear], startPoint: .top, endPoint: .bottom)

--- a/DLPrototype/Views/Shared/AppSidebar/Widgets/JobsWidget.swift
+++ b/DLPrototype/Views/Shared/AppSidebar/Widgets/JobsWidget.swift
@@ -74,6 +74,7 @@ struct JobsWidgetRedux: View {
                         .background(self.showPublished ? Theme.textBackground : .white.opacity(0.5))
                         .foregroundStyle(self.showPublished ? .white : Theme.base)
                         .clipShape(RoundedRectangle(cornerRadius: 5))
+                        .help("Show or hide unpublished items")
                 }
                 .font(.caption)
                 .padding(8)
@@ -292,7 +293,7 @@ struct UnifiedSidebar {
                         .useDefaultHover({ inside in self.highlighted = inside})
                     RowAddNavLink(
                         title: "Add",
-                        target: AnyView(EmptyView())
+                        target: AnyView(TaskDashboard())
                     )
                     .buttonStyle(.plain)
                 }
@@ -340,7 +341,7 @@ struct UnifiedSidebar {
                         .useDefaultHover({ inside in self.highlighted = inside})
                     RowAddNavLink(
                         title: "Add",
-                        target: AnyView(EmptyView())
+                        target: AnyView(NoteCreate())
                     )
                     .buttonStyle(.plain)
                 }
@@ -388,7 +389,7 @@ struct UnifiedSidebar {
                         .useDefaultHover({ inside in self.highlighted = inside})
                     RowAddNavLink(
                         title: "Add",
-                        target: AnyView(EmptyView())
+                        target: AnyView(DefinitionDetail())
                     )
                     .buttonStyle(.plain)
                 }
@@ -447,7 +448,7 @@ struct UnifiedSidebar {
                                 ForEach(self.records, id: \.objectID) { record in
                                     if record.message != nil {
                                         Button {
-//                                            self.state.to(.taskDetail)
+                                            self.state.to(.today)
                                         } label: {
                                             Text(record.message!)
                                         }

--- a/DLPrototype/Views/Shared/AppSidebar/Widgets/JobsWidget.swift
+++ b/DLPrototype/Views/Shared/AppSidebar/Widgets/JobsWidget.swift
@@ -123,11 +123,12 @@ struct UnifiedSidebar {
                             .opacity(0.7)
                             .padding(.leading)
                         Spacer()
-                        RowAddNavLink(
-                            title: "+ Person",
-                            target: AnyView(EmptyView())
-                        )
-                        .buttonStyle(.plain)
+                        // @TODO: uncomment when people entities has been implemented
+//                        RowAddNavLink(
+//                            title: "+ Person",
+//                            target: AnyView(EmptyView())
+//                        )
+//                        .buttonStyle(.plain)
                         RowAddNavLink(
                             title: "+ Project",
                             target: AnyView(ProjectCreate())
@@ -403,7 +404,7 @@ struct UnifiedSidebar {
                                 ForEach(self.definitions, id: \.objectID) { def in
                                     if def.definition != nil {
                                         Button {
-//                                            self.state.to(.taskDetail)
+                                            self.state.to(.definitionDetail)
                                         } label: {
                                             Text(def.definition ?? "_NO_DEFINITION")
                                         }
@@ -433,11 +434,6 @@ struct UnifiedSidebar {
                 ZStack(alignment: .trailing) {
                     EntityRowButton(text: "\(self.records.count) Records", isPresented: $isPresented)
                         .useDefaultHover({ inside in self.highlighted = inside})
-                    RowAddNavLink(
-                        title: "Add",
-                        target: AnyView(EmptyView())
-                    )
-                    .buttonStyle(.plain)
                 }
                 .background(Theme.base.opacity(0.6).blendMode(.softLight))
 
@@ -480,11 +476,12 @@ struct UnifiedSidebar {
                 ZStack(alignment: .trailing) {
                     EntityRowButton(text: "People", isPresented: $isPresented)
                         .useDefaultHover({ inside in self.highlighted = inside})
-                    RowAddNavLink(
-                        title: "Add",
-                        target: AnyView(EmptyView())
-                    )
-                    .buttonStyle(.plain)
+                    // @TODO: uncomment when people entities has been implemented
+//                    RowAddNavLink(
+//                        title: "Add",
+//                        target: AnyView(EmptyView())
+//                    )
+//                    .buttonStyle(.plain)
                 }
                 .background(Theme.base.opacity(0.6).blendMode(.softLight))
 

--- a/DLPrototype/Views/Shared/AppSidebar/Widgets/JobsWidget.swift
+++ b/DLPrototype/Views/Shared/AppSidebar/Widgets/JobsWidget.swift
@@ -98,6 +98,7 @@ extension JobsWidgetRedux {
 
 struct UnifiedSidebar {
     struct SingleCompany: View {
+        @EnvironmentObject private var state: Navigation
         public let company: Company
         @State private var isPresented: Bool = false
         @State private var highlighted: Bool = false
@@ -105,8 +106,15 @@ struct UnifiedSidebar {
 
         var body: some View {
             VStack(alignment: .leading, spacing: 0) {
-                RowButton(text: self.company.name ?? "_COMPANY_NAME", alive: self.company.alive, isPresented: $isPresented)
-                    .useDefaultHover({ inside in self.highlighted = inside})
+                ZStack(alignment: .trailing) {
+                    RowButton(text: self.company.name ?? "_COMPANY_NAME", alive: self.company.alive, isPresented: $isPresented)
+                        .useDefaultHover({ inside in self.highlighted = inside})
+
+                    if self.company == self.state.session.job?.project?.company {
+                        FancyStarv2()
+                            .help("Currently selected job")
+                    }
+                }
 
                 if self.isPresented {
                     HStack(alignment: .center, spacing: 0) {
@@ -154,6 +162,7 @@ struct UnifiedSidebar {
     }
 
     struct SingleProject: View {
+        @EnvironmentObject private var state: Navigation
         public let project: Project
         @State private var isPresented: Bool = false
         @State private var highlighted: Bool = false
@@ -161,8 +170,15 @@ struct UnifiedSidebar {
 
         var body: some View {
             VStack(alignment: .leading, spacing: 0) {
-                RowButton(text: self.project.name ?? "_PROJECT_NAME", alive: self.project.alive, isPresented: $isPresented)
-                    .useDefaultHover({ inside in self.highlighted = inside})
+                ZStack(alignment: .trailing) {
+                    RowButton(text: self.project.name ?? "_PROJECT_NAME", alive: self.project.alive, isPresented: $isPresented)
+                        .useDefaultHover({ inside in self.highlighted = inside})
+
+                    if self.project == self.state.session.job?.project {
+                        FancyStarv2()
+                            .help("Currently selected job")
+                    }
+                }
 
                 if self.isPresented {
                     HStack(alignment: .center, spacing: 0) {
@@ -186,7 +202,7 @@ struct UnifiedSidebar {
                                 .opacity(0.6)
                                 .blendMode(.softLight)
                             VStack(alignment: .leading, spacing: 0) {
-                                ForEach((self.project.jobs?.allObjects as? [Job] ?? []).sorted(by: {$0.created! > $1.created!}), id: \.objectID) { job in
+                                ForEach((self.project.jobs?.allObjects as? [Job] ?? []).sorted(by: {$0.created ?? Date() > $1.created ?? Date()}), id: \.objectID) { job in
                                     if !showPublished || job.alive {
                                         SingleJob(job: job)
                                     }
@@ -211,10 +227,17 @@ struct UnifiedSidebar {
 
         var body: some View {
             VStack(alignment: .leading, spacing: 0) {
-                RowButton(text: self.job.title ?? self.job.jid.string, alive: self.job.alive, callback: {
-                    self.state.session.setJob(self.job)
-                }, isPresented: $isPresented)
-                .useDefaultHover({ inside in self.highlighted = inside})
+                ZStack(alignment: .trailing) {
+                    RowButton(text: self.job.title ?? self.job.jid.string, alive: self.job.alive, callback: {
+                        self.state.session.setJob(self.job)
+                    }, isPresented: $isPresented)
+                    .useDefaultHover({ inside in self.highlighted = inside})
+
+                    if self.job == self.state.session.job {
+                        FancyStarv2()
+                            .help("Currently selected job")
+                    }
+                }
 
                 if self.isPresented {
                     VStack(alignment: .leading, spacing: 0) {

--- a/DLPrototype/Views/Shared/AppSidebar/Widgets/JobsWidget.swift
+++ b/DLPrototype/Views/Shared/AppSidebar/Widgets/JobsWidget.swift
@@ -53,20 +53,38 @@ extension JobsWidget {
 }
 
 struct JobsWidgetRedux: View {
-    @FetchRequest public var companies: FetchedResults<Company>
+    @EnvironmentObject public var state: Navigation
+    @State private var showPublished: Bool = true
+    @State private var companies: [Company] = []
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
+            HStack(alignment: .center, spacing: 8) {
+                Spacer()
+                Toggle("Published", isOn: $showPublished)
+                    .font(.caption)
+                    .padding(6)
+                    .background(self.showPublished ? Theme.textBackground : .white.opacity(0.5))
+                    .foregroundStyle(self.showPublished ? .white : Theme.base)
+                    .clipShape(RoundedRectangle(cornerRadius: 5))
+            }
+            .padding(8)
+            .background(Theme.base.opacity(0.2))
+
             ForEach(self.companies, id: \.objectID) { company in
                 UnifiedSidebar.SingleCompany(company: company)
             }
         }
+        .onAppear(perform: self.actionOnAppear)
+        .onChange(of: self.showPublished) { self.actionOnAppear() }
     }
 }
 
 extension JobsWidgetRedux {
-    public init() {
-        _companies = CoreDataCompanies.fetch(true)
+    /// Onload handler. Finds companies
+    /// - Returns: Void
+    private func actionOnAppear() -> Void {
+        self.companies = CoreDataCompanies(moc: self.state.moc).all(allowKilled: self.showPublished)
     }
 }
 

--- a/DLPrototype/Views/Shared/AppSidebar/Widgets/JobsWidget.swift
+++ b/DLPrototype/Views/Shared/AppSidebar/Widgets/JobsWidget.swift
@@ -471,7 +471,7 @@ struct UnifiedSidebar {
                 self.callback?()
             } label: {
                 HStack(alignment: .center, spacing: 8) {
-                    ZStack {
+                    ZStack(alignment: .center) {
                         Theme.base.opacity(0.6).blendMode(.softLight)
                         Image(systemName: self.isPresented ? "minus" : "plus")
                     }
@@ -506,10 +506,10 @@ struct UnifiedSidebar {
                 isPresented.toggle()
                 self.callback?()
             } label: {
-                ZStack {
+                ZStack(alignment: .topLeading) {
                     Theme.base.opacity(0.6).blendMode(.softLight)
                     HStack(alignment: .center, spacing: 8) {
-                        ZStack {
+                        ZStack(alignment: .center) {
                             Theme.base.opacity(0.6).blendMode(.softLight)
                             Image(systemName: self.isPresented ? "minus" : "plus")
                         }

--- a/DLPrototype/Views/Shared/AppSidebar/Widgets/JobsWidget.swift
+++ b/DLPrototype/Views/Shared/AppSidebar/Widgets/JobsWidget.swift
@@ -139,6 +139,8 @@ struct UnifiedSidebar {
                                 ForEach(self.company.projects?.allObjects as? [Project] ?? [], id: \.objectID) { project in
                                     SingleProject(project: project)
                                 }
+
+                                People(entity: self.company)
                             }
                             .padding(.leading, 15)
                         }
@@ -186,7 +188,6 @@ struct UnifiedSidebar {
                                 ForEach(self.project.jobs?.allObjects as? [Job] ?? [], id: \.objectID) { job in
                                     SingleJob(job: job)
                                 }
-                                People(project: self.project)
                             }
                             .padding(.leading, 15)
                         }
@@ -342,13 +343,13 @@ struct UnifiedSidebar {
 
     struct People: View {
         @EnvironmentObject private var state: Navigation
-        public let project: Project
+        public let entity: Company
         @State private var isPresented: Bool = false
         @State private var highlighted: Bool = false
 
         var body: some View {
             VStack(alignment: .leading, spacing: 0) {
-                RowButton(text: "People", alive: self.project.alive, isPresented: $isPresented)
+                RowButton(text: "People", alive: self.entity.alive, isPresented: $isPresented)
                     .useDefaultHover({ inside in self.highlighted = inside})
 
                 if self.isPresented {
@@ -370,7 +371,7 @@ struct UnifiedSidebar {
                                 .blendMode(.softLight)
                                 .frame(height: 50)
                             VStack(alignment: .leading, spacing: 0) {
-                                ForEach(self.project.company?.people?.allObjects as? [Person] ?? [], id: \.objectID) { person in
+                                ForEach(self.entity.people?.allObjects as? [Person] ?? [], id: \.objectID) { person in
                                     if person.name != nil {
                                         Button {
                                             self.state.to(.taskDetail)
@@ -386,8 +387,8 @@ struct UnifiedSidebar {
                     }
                 }
             }
-            .background(self.project.alive ? self.highlighted ? self.project.backgroundColor.opacity(0.9) : self.project.backgroundColor : .gray.opacity(0.8))
-            .foregroundStyle((self.project.alive ? self.project.backgroundColor : .gray).isBright() ? Theme.base : .white)
+            .background(self.entity.alive ? self.highlighted ? self.entity.backgroundColor.opacity(0.9) : self.entity.backgroundColor : .gray.opacity(0.8))
+            .foregroundStyle((self.entity.alive ? self.entity.backgroundColor : .gray).isBright() ? Theme.base : .white)
         }
     }
 

--- a/DLPrototype/Views/Shared/AppSidebar/Widgets/JobsWidget.swift
+++ b/DLPrototype/Views/Shared/AppSidebar/Widgets/JobsWidget.swift
@@ -136,7 +136,7 @@ struct UnifiedSidebar {
                                 .blendMode(.softLight)
                                 .frame(height: 50)
                             VStack(alignment: .leading, spacing: 0) {
-                                ForEach(self.company.projects?.allObjects as? [Project] ?? [], id: \.objectID) { project in
+                                ForEach((self.company.projects?.allObjects as? [Project] ?? []).sorted(by: {$0.created! > $1.created!}), id: \.objectID) { project in
                                     if !showPublished || project.alive {
                                         SingleProject(project: project)
                                     }
@@ -188,7 +188,7 @@ struct UnifiedSidebar {
                                 .blendMode(.softLight)
                                 .frame(height: 50)
                             VStack(alignment: .leading, spacing: 0) {
-                                ForEach(self.project.jobs?.allObjects as? [Job] ?? [], id: \.objectID) { job in
+                                ForEach((self.project.jobs?.allObjects as? [Job] ?? []).sorted(by: {$0.created! > $1.created!}), id: \.objectID) { job in
                                     if !showPublished || job.alive {
                                         SingleJob(job: job)
                                     }

--- a/DLPrototype/Views/Shared/AppSidebar/Widgets/JobsWidget.swift
+++ b/DLPrototype/Views/Shared/AppSidebar/Widgets/JobsWidget.swift
@@ -59,17 +59,26 @@ struct JobsWidgetRedux: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
-            HStack(alignment: .center, spacing: 8) {
-                Spacer()
-                Toggle("Published", isOn: $showPublished)
-                    .font(.caption)
-                    .padding(6)
-                    .background(self.showPublished ? Theme.textBackground : .white.opacity(0.5))
-                    .foregroundStyle(self.showPublished ? .white : Theme.base)
-                    .clipShape(RoundedRectangle(cornerRadius: 5))
+            ZStack {
+                Theme.base.opacity(0.2)
+                LinearGradient(colors: [Theme.base, .clear], startPoint: .bottom, endPoint: .top)
+                    .opacity(0.6)
+                    .blendMode(.softLight)
+                    .frame(height: 50)
+                
+                HStack(alignment: .center, spacing: 8) {
+                    Text("\(self.companies.count) Companies")
+                    Spacer()
+                    Toggle("Published", isOn: $showPublished)
+                        .padding(6)
+                        .background(self.showPublished ? Theme.textBackground : .white.opacity(0.5))
+                        .foregroundStyle(self.showPublished ? .white : Theme.base)
+                        .clipShape(RoundedRectangle(cornerRadius: 5))
+                }
+                .font(.caption)
+                .padding(8)
+//                .background(Theme.base.opacity(0.2))
             }
-            .padding(8)
-            .background(Theme.base.opacity(0.2))
 
             ForEach(self.companies, id: \.objectID) { company in
                 UnifiedSidebar.SingleCompany(company: company)
@@ -101,6 +110,10 @@ struct UnifiedSidebar {
 
                 if self.isPresented {
                     HStack(alignment: .center, spacing: 0) {
+                        Text(self.company.abbreviation ?? "XXX")
+                            .foregroundStyle(self.company.backgroundColor.isBright() ? Theme.base : .white)
+                            .opacity(0.7)
+                            .padding(.leading)
                         Spacer()
                         RowAddNavLink(
                             title: "+ Person",
@@ -149,15 +162,14 @@ struct UnifiedSidebar {
 
                 if self.isPresented {
                     HStack(alignment: .center, spacing: 0) {
+                        Text("\(self.project.company?.abbreviation ?? "XXX").\(self.project.abbreviation ?? "YYY")")
+                            .foregroundStyle(self.project.backgroundColor.isBright() ? Theme.base : .white)
+                            .opacity(0.7)
+                            .padding(.leading)
                         Spacer()
                         RowAddNavLink(
-                            title: "+ Person",
-                            target: AnyView(EmptyView())
-                        )
-                        .buttonStyle(.plain)
-                        RowAddNavLink(
-                            title: "+ Project",
-                            target: AnyView(ProjectCreate())
+                            title: "+ Job",
+                            target: AnyView(JobCreate())
                         )
                         .buttonStyle(.plain)
                     }
@@ -174,6 +186,7 @@ struct UnifiedSidebar {
                                 ForEach(self.project.jobs?.allObjects as? [Job] ?? [], id: \.objectID) { job in
                                     SingleJob(job: job)
                                 }
+                                People(project: self.project)
                             }
                             .padding(.leading, 15)
                         }
@@ -199,17 +212,6 @@ struct UnifiedSidebar {
                 .useDefaultHover({ inside in self.highlighted = inside})
 
                 if self.isPresented {
-                    HStack(alignment: .center, spacing: 0) {
-                        Spacer()
-                        RowAddNavLink(
-                            title: "+ Job",
-                            target: AnyView(JobCreate())
-                        )
-                        .buttonStyle(.plain)
-                    }
-                    .padding([.top, .bottom], 8)
-                    .background(Theme.base.opacity(0.6).blendMode(.softLight))
-
                     VStack(alignment: .leading, spacing: 0) {
                         ZStack(alignment: .topLeading) {
                             LinearGradient(colors: [Theme.base, .clear], startPoint: .top, endPoint: .bottom)
@@ -335,6 +337,57 @@ struct UnifiedSidebar {
             }
             .background(self.job.alive ? self.highlighted ? self.job.backgroundColor.opacity(0.9) : self.job.backgroundColor : .gray.opacity(0.8))
             .foregroundStyle((self.job.alive ? self.job.backgroundColor : .gray).isBright() ? Theme.base : .white)
+        }
+    }
+
+    struct People: View {
+        @EnvironmentObject private var state: Navigation
+        public let project: Project
+        @State private var isPresented: Bool = false
+        @State private var highlighted: Bool = false
+
+        var body: some View {
+            VStack(alignment: .leading, spacing: 0) {
+                RowButton(text: "People", alive: self.project.alive, isPresented: $isPresented)
+                    .useDefaultHover({ inside in self.highlighted = inside})
+
+                if self.isPresented {
+                    HStack(alignment: .center, spacing: 0) {
+                        Spacer()
+                        RowAddNavLink(
+                            title: "+ Task",
+                            target: AnyView(EmptyView())
+                        )
+                        .buttonStyle(.plain)
+                    }
+                    .padding([.top, .bottom], 8)
+                    .background(Theme.base.opacity(0.6).blendMode(.softLight))
+
+                    VStack(alignment: .leading, spacing: 0) {
+                        ZStack(alignment: .topLeading) {
+                            LinearGradient(colors: [Theme.base, .clear], startPoint: .top, endPoint: .bottom)
+                                .opacity(0.6)
+                                .blendMode(.softLight)
+                                .frame(height: 50)
+                            VStack(alignment: .leading, spacing: 0) {
+                                ForEach(self.project.company?.people?.allObjects as? [Person] ?? [], id: \.objectID) { person in
+                                    if person.name != nil {
+                                        Button {
+                                            self.state.to(.taskDetail)
+                                        } label: {
+                                            Text(person.name!)
+                                        }
+                                        .buttonStyle(.plain)
+                                    }
+                                }
+                            }
+                            .padding(.leading, 15)
+                        }
+                    }
+                }
+            }
+            .background(self.project.alive ? self.highlighted ? self.project.backgroundColor.opacity(0.9) : self.project.backgroundColor : .gray.opacity(0.8))
+            .foregroundStyle((self.project.alive ? self.project.backgroundColor : .gray).isBright() ? Theme.base : .white)
         }
     }
 

--- a/DLPrototype/Views/Shared/AppSidebar/Widgets/JobsWidget.swift
+++ b/DLPrototype/Views/Shared/AppSidebar/Widgets/JobsWidget.swift
@@ -78,27 +78,8 @@ struct UnifiedSidebar {
 
         var body: some View {
             VStack(alignment: .leading, spacing: 0) {
-                Button {
-                    self.isPresented.toggle()
-                } label: {
-                    HStack(alignment: .center, spacing: 8) {
-                        ZStack {
-                            Theme.base.opacity(0.6).blendMode(.softLight)
-                            Image(systemName: self.isPresented ? "minus" : "plus")
-                                .foregroundStyle(.white)
-                        }
-                        .frame(width: 30, height: 30)
-                        .cornerRadius(5)
-
-                        Text(self.company.name ?? "_COMPANY_NAME")
-                            .font(.title3)
-                            .multilineTextAlignment(.leading)
-                        Spacer()
-                    }
-                }
-                .padding(8)
-                .buttonStyle(.plain)
-                .useDefaultHover({ inside in self.highlighted = inside})
+                RowButton(text: self.company.name ?? "_COMPANY_NAME", alive: self.company.alive, isPresented: $isPresented)
+                    .useDefaultHover({ inside in self.highlighted = inside})
 
                 if self.isPresented {
                     HStack(alignment: .center, spacing: 0) {
@@ -134,7 +115,7 @@ struct UnifiedSidebar {
                 }
             }
             .background(self.company.alive ? self.highlighted ? self.company.backgroundColor.opacity(0.9) : self.company.backgroundColor : .gray.opacity(0.8))
-            .foregroundStyle((self.company.alive ? self.company.backgroundColor : .gray).isBright() ? .black : .white)
+            .foregroundStyle((self.company.alive ? self.company.backgroundColor : .gray).isBright() ? Theme.base : .white)
         }
     }
 
@@ -145,27 +126,8 @@ struct UnifiedSidebar {
 
         var body: some View {
             VStack(alignment: .leading, spacing: 0) {
-                Button {
-                    self.isPresented.toggle()
-                } label: {
-                    HStack(alignment: .center, spacing: 8) {
-                        ZStack {
-                            Theme.base.opacity(0.6).blendMode(.softLight)
-                            Image(systemName: self.isPresented ? "minus" : "plus")
-                                .foregroundStyle(.white)
-                        }
-                        .frame(width: 30, height: 30)
-                        .cornerRadius(5)
-
-                        Text(self.project.name ?? "_PROJECT_NAME")
-                            .font(.title3)
-                            .multilineTextAlignment(.leading)
-                        Spacer()
-                    }
-                }
-                .padding(8)
-                .buttonStyle(.plain)
-                .useDefaultHover({ inside in self.highlighted = inside})
+                RowButton(text: self.project.name ?? "_PROJECT_NAME", alive: self.project.alive, isPresented: $isPresented)
+                    .useDefaultHover({ inside in self.highlighted = inside})
 
                 if self.isPresented {
                     HStack(alignment: .center, spacing: 0) {
@@ -201,7 +163,7 @@ struct UnifiedSidebar {
                 }
             }
             .background(self.project.alive ? self.highlighted ? self.project.backgroundColor.opacity(0.9) : self.project.backgroundColor : .gray.opacity(0.8))
-            .foregroundStyle((self.project.alive ? self.project.backgroundColor : .gray).isBright() ? .black : .white)
+            .foregroundStyle((self.project.alive ? self.project.backgroundColor : .gray).isBright() ? Theme.base : .white)
         }
     }
 
@@ -213,27 +175,9 @@ struct UnifiedSidebar {
 
         var body: some View {
             VStack(alignment: .leading, spacing: 0) {
-                Button {
-                    self.isPresented.toggle()
+                RowButton(text: self.job.title ?? self.job.jid.string, alive: self.job.alive, callback: {
                     self.state.session.setJob(self.job)
-                } label: {
-                    HStack(alignment: .center, spacing: 8) {
-                        ZStack {
-                            Theme.base.opacity(0.6).blendMode(.softLight)
-                            Image(systemName: self.isPresented ? "minus" : "plus")
-                                .foregroundStyle(.white)
-                        }
-                        .frame(width: 30, height: 30)
-                        .cornerRadius(5)
-
-                        Text(self.job.title ?? self.job.jid.string)
-                            .font(.title3)
-                            .multilineTextAlignment(.leading)
-                        Spacer()
-                    }
-                }
-                .padding(8)
-                .buttonStyle(.plain)
+                }, isPresented: $isPresented)
                 .useDefaultHover({ inside in self.highlighted = inside})
 
                 if self.isPresented {
@@ -258,6 +202,9 @@ struct UnifiedSidebar {
                                 if let tasks = self.job.tasks?.allObjects as? [LogTask] {
                                     Tasks(job: self.job, tasks: tasks)
                                 }
+                                if let notes = self.job.mNotes?.allObjects as? [Note] {
+                                    Notes(job: self.job, notes: notes)
+                                }
                             }
                             .padding(.leading, 15)
                         }
@@ -265,7 +212,7 @@ struct UnifiedSidebar {
                 }
             }
             .background(self.job.alive ? self.highlighted ? self.job.backgroundColor.opacity(0.9) : self.job.backgroundColor : .gray.opacity(0.8))
-            .foregroundStyle((self.job.alive ? self.job.backgroundColor : .gray).isBright() ? .black : .white)
+            .foregroundStyle((self.job.alive ? self.job.backgroundColor : .gray).isBright() ? Theme.base : .white)
         }
     }
 
@@ -278,27 +225,8 @@ struct UnifiedSidebar {
 
         var body: some View {
             VStack(alignment: .leading, spacing: 0) {
-                Button {
-                    self.isPresented.toggle()
-                } label: {
-                    HStack(alignment: .center, spacing: 8) {
-                        ZStack {
-                            Theme.base.opacity(0.6).blendMode(.softLight)
-                            Image(systemName: self.isPresented ? "minus" : "plus")
-                                .foregroundStyle(.white)
-                        }
-                        .frame(width: 30, height: 30)
-                        .cornerRadius(5)
-
-                        Text("Tasks")
-                            .font(.title3)
-                            .multilineTextAlignment(.leading)
-                        Spacer()
-                    }
-                }
-                .padding(8)
-                .buttonStyle(.plain)
-                .useDefaultHover({ inside in self.highlighted = inside})
+                RowButton(text: "Tasks", alive: self.job.alive, isPresented: $isPresented)
+                    .useDefaultHover({ inside in self.highlighted = inside})
 
                 if self.isPresented {
                     HStack(alignment: .center, spacing: 0) {
@@ -336,7 +264,96 @@ struct UnifiedSidebar {
                 }
             }
             .background(self.job.alive ? self.highlighted ? self.job.backgroundColor.opacity(0.9) : self.job.backgroundColor : .gray.opacity(0.8))
-            .foregroundStyle((self.job.alive ? self.job.backgroundColor : .gray).isBright() ? .black : .white)
+            .foregroundStyle((self.job.alive ? self.job.backgroundColor : .gray).isBright() ? Theme.base : .white)
+        }
+    }
+
+    struct Notes: View {
+        @EnvironmentObject private var state: Navigation
+        public let job: Job
+        public let notes: [Note]
+        @State private var isPresented: Bool = false
+        @State private var highlighted: Bool = false
+
+        var body: some View {
+            VStack(alignment: .leading, spacing: 0) {
+                RowButton(text: "Notes", alive: self.job.alive, isPresented: $isPresented)
+                    .useDefaultHover({ inside in self.highlighted = inside})
+
+                if self.isPresented {
+                    HStack(alignment: .center, spacing: 0) {
+                        Spacer()
+                        RowAddNavLink(
+                            title: "+ Note",
+                            target: AnyView(EmptyView())
+                        )
+                        .buttonStyle(.plain)
+                    }
+                    .padding([.top, .bottom], 8)
+                    .background(Theme.base.opacity(0.6).blendMode(.softLight))
+
+                    VStack(alignment: .leading, spacing: 0) {
+                        ZStack(alignment: .topLeading) {
+                            LinearGradient(colors: [Theme.base, .clear], startPoint: .top, endPoint: .bottom)
+                                .opacity(0.6)
+                                .blendMode(.softLight)
+                                .frame(height: 50)
+                            VStack(alignment: .leading, spacing: 0) {
+                                ForEach(self.notes, id: \.objectID) { note in
+                                    if note.title != nil {
+                                        Button {
+                                            self.state.to(.taskDetail)
+                                        } label: {
+                                            Text(note.title!)
+                                        }
+                                        .buttonStyle(.plain)
+                                    }
+                                }
+                            }
+                            .padding(.leading, 15)
+                        }
+                    }
+                }
+            }
+            .background(self.job.alive ? self.highlighted ? self.job.backgroundColor.opacity(0.9) : self.job.backgroundColor : .gray.opacity(0.8))
+            .foregroundStyle((self.job.alive ? self.job.backgroundColor : .gray).isBright() ? Theme.base : .white)
+        }
+    }
+
+    struct RowButton: View {
+        public let text: String
+        public let alive: Bool
+        public var callback: (() -> Void)?
+        @Binding public var isPresented: Bool
+
+        var body: some View {
+            Button {
+                isPresented.toggle()
+                self.callback?()
+            } label: {
+                HStack(alignment: .center, spacing: 8) {
+                    ZStack {
+                        Theme.base.opacity(0.6).blendMode(.softLight)
+                        Image(systemName: self.isPresented ? "minus" : "plus")
+                    }
+                    .frame(width: 30, height: 30)
+                    .cornerRadius(5)
+
+                    Text(self.text)
+                        .font(.title3)
+                        .multilineTextAlignment(.leading)
+                    Spacer()
+
+                    if !self.alive {
+                        Image(systemName: "snowflake")
+                            .font(.title3)
+                            .opacity(0.5)
+                            .help("Unpublished")
+                    }
+                }
+            }
+            .padding(8)
+            .buttonStyle(.plain)
         }
     }
 }

--- a/DLPrototype/Views/Shared/AppSidebar/Widgets/JobsWidget.swift
+++ b/DLPrototype/Views/Shared/AppSidebar/Widgets/JobsWidget.swift
@@ -134,7 +134,6 @@ struct UnifiedSidebar {
                             LinearGradient(colors: [Theme.base, .clear], startPoint: .top, endPoint: .bottom)
                                 .opacity(0.6)
                                 .blendMode(.softLight)
-                                .frame(height: 50)
                             VStack(alignment: .leading, spacing: 0) {
                                 ForEach((self.company.projects?.allObjects as? [Project] ?? []).sorted(by: {$0.created! > $1.created!}), id: \.objectID) { project in
                                     if !showPublished || project.alive {
@@ -186,7 +185,6 @@ struct UnifiedSidebar {
                             LinearGradient(colors: [Theme.base, .clear], startPoint: .top, endPoint: .bottom)
                                 .opacity(0.6)
                                 .blendMode(.softLight)
-                                .frame(height: 50)
                             VStack(alignment: .leading, spacing: 0) {
                                 ForEach((self.project.jobs?.allObjects as? [Job] ?? []).sorted(by: {$0.created! > $1.created!}), id: \.objectID) { job in
                                     if !showPublished || job.alive {
@@ -224,7 +222,6 @@ struct UnifiedSidebar {
                             LinearGradient(colors: [Theme.base, .clear], startPoint: .top, endPoint: .bottom)
                                 .opacity(0.6)
                                 .blendMode(.softLight)
-                                .frame(height: 50)
                             VStack(alignment: .leading, spacing: 0) {
                                 if let tasks = self.job.tasks?.allObjects as? [LogTask] {
                                     if tasks.count > 0 {
@@ -283,7 +280,6 @@ struct UnifiedSidebar {
                             LinearGradient(colors: [Theme.base, .clear], startPoint: .top, endPoint: .bottom)
                                 .opacity(0.6)
                                 .blendMode(.softLight)
-                                .frame(height: 50)
                             VStack(alignment: .leading, spacing: 0) {
                                 ForEach(self.tasks, id: \.objectID) { task in
                                     if task.content != nil {
@@ -332,7 +328,6 @@ struct UnifiedSidebar {
                             LinearGradient(colors: [Theme.base, .clear], startPoint: .top, endPoint: .bottom)
                                 .opacity(0.6)
                                 .blendMode(.softLight)
-                                .frame(height: 50)
                             VStack(alignment: .leading, spacing: 0) {
                                 ForEach(self.notes, id: \.objectID) { note in
                                     if note.title != nil {
@@ -381,7 +376,6 @@ struct UnifiedSidebar {
                             LinearGradient(colors: [Theme.base, .clear], startPoint: .top, endPoint: .bottom)
                                 .opacity(0.6)
                                 .blendMode(.softLight)
-                                .frame(height: 50)
                             VStack(alignment: .leading, spacing: 0) {
                                 ForEach(self.definitions, id: \.objectID) { def in
                                     if def.definition != nil {
@@ -430,7 +424,6 @@ struct UnifiedSidebar {
                             LinearGradient(colors: [Theme.base, .clear], startPoint: .top, endPoint: .bottom)
                                 .opacity(0.6)
                                 .blendMode(.softLight)
-                                .frame(height: 50)
                             VStack(alignment: .leading, spacing: 0) {
                                 ForEach(self.records, id: \.objectID) { record in
                                     if record.message != nil {

--- a/DLPrototype/Views/Shared/AppSidebar/Widgets/JobsWidget.swift
+++ b/DLPrototype/Views/Shared/AppSidebar/Widgets/JobsWidget.swift
@@ -51,3 +51,292 @@ extension JobsWidget {
     }
 
 }
+
+struct JobsWidgetRedux: View {
+    @FetchRequest public var companies: FetchedResults<Company>
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            ForEach(self.companies, id: \.objectID) { company in
+                UnifiedSidebar.SingleCompany(company: company)
+            }
+        }
+    }
+}
+
+extension JobsWidgetRedux {
+    public init() {
+        _companies = CoreDataCompanies.fetch(true)
+    }
+}
+
+struct UnifiedSidebar {
+    struct SingleCompany: View {
+        public let company: Company
+        @State private var isPresented: Bool = false
+        @State private var highlighted: Bool = false
+
+        var body: some View {
+            VStack(alignment: .leading, spacing: 0) {
+                Button {
+                    self.isPresented.toggle()
+                } label: {
+                    HStack(alignment: .center, spacing: 8) {
+                        ZStack {
+                            Theme.base.opacity(0.6).blendMode(.softLight)
+                            Image(systemName: self.isPresented ? "minus" : "plus")
+                                .foregroundStyle(.white)
+                        }
+                        .frame(width: 30, height: 30)
+                        .cornerRadius(5)
+
+                        Text(self.company.name ?? "_COMPANY_NAME")
+                            .font(.title3)
+                            .multilineTextAlignment(.leading)
+                        Spacer()
+                    }
+                }
+                .padding(8)
+                .buttonStyle(.plain)
+                .useDefaultHover({ inside in self.highlighted = inside})
+
+                if self.isPresented {
+                    HStack(alignment: .center, spacing: 0) {
+                        Spacer()
+                        RowAddNavLink(
+                            title: "+ Person",
+                            target: AnyView(EmptyView())
+                        )
+                        .buttonStyle(.plain)
+                        RowAddNavLink(
+                            title: "+ Project",
+                            target: AnyView(ProjectCreate())
+                        )
+                        .buttonStyle(.plain)
+                    }
+                    .padding([.top, .bottom], 8)
+                    .background(Theme.base.opacity(0.6).blendMode(.softLight))
+
+                    VStack(alignment: .leading, spacing: 0) {
+                        ZStack(alignment: .topLeading) {
+                            LinearGradient(colors: [Theme.base, .clear], startPoint: .top, endPoint: .bottom)
+                                .opacity(0.6)
+                                .blendMode(.softLight)
+                                .frame(height: 50)
+                            VStack(alignment: .leading, spacing: 0) {
+                                ForEach(self.company.projects?.allObjects as? [Project] ?? [], id: \.objectID) { project in
+                                    SingleProject(project: project)
+                                }
+                            }
+                            .padding(.leading, 15)
+                        }
+                    }
+                }
+            }
+            .background(self.company.alive ? self.highlighted ? self.company.backgroundColor.opacity(0.9) : self.company.backgroundColor : .gray.opacity(0.8))
+            .foregroundStyle((self.company.alive ? self.company.backgroundColor : .gray).isBright() ? .black : .white)
+        }
+    }
+
+    struct SingleProject: View {
+        public let project: Project
+        @State private var isPresented: Bool = false
+        @State private var highlighted: Bool = false
+
+        var body: some View {
+            VStack(alignment: .leading, spacing: 0) {
+                Button {
+                    self.isPresented.toggle()
+                } label: {
+                    HStack(alignment: .center, spacing: 8) {
+                        ZStack {
+                            Theme.base.opacity(0.6).blendMode(.softLight)
+                            Image(systemName: self.isPresented ? "minus" : "plus")
+                                .foregroundStyle(.white)
+                        }
+                        .frame(width: 30, height: 30)
+                        .cornerRadius(5)
+
+                        Text(self.project.name ?? "_PROJECT_NAME")
+                            .font(.title3)
+                            .multilineTextAlignment(.leading)
+                        Spacer()
+                    }
+                }
+                .padding(8)
+                .buttonStyle(.plain)
+                .useDefaultHover({ inside in self.highlighted = inside})
+
+                if self.isPresented {
+                    HStack(alignment: .center, spacing: 0) {
+                        Spacer()
+                        RowAddNavLink(
+                            title: "+ Person",
+                            target: AnyView(EmptyView())
+                        )
+                        .buttonStyle(.plain)
+                        RowAddNavLink(
+                            title: "+ Project",
+                            target: AnyView(ProjectCreate())
+                        )
+                        .buttonStyle(.plain)
+                    }
+                    .padding([.top, .bottom], 8)
+                    .background(Theme.base.opacity(0.6).blendMode(.softLight))
+
+                    VStack(alignment: .leading, spacing: 0) {
+                        ZStack(alignment: .topLeading) {
+                            LinearGradient(colors: [Theme.base, .clear], startPoint: .top, endPoint: .bottom)
+                                .opacity(0.6)
+                                .blendMode(.softLight)
+                                .frame(height: 50)
+                            VStack(alignment: .leading, spacing: 0) {
+                                ForEach(self.project.jobs?.allObjects as? [Job] ?? [], id: \.objectID) { job in
+                                    SingleJob(job: job)
+                                }
+                            }
+                            .padding(.leading, 15)
+                        }
+                    }
+                }
+            }
+            .background(self.project.alive ? self.highlighted ? self.project.backgroundColor.opacity(0.9) : self.project.backgroundColor : .gray.opacity(0.8))
+            .foregroundStyle((self.project.alive ? self.project.backgroundColor : .gray).isBright() ? .black : .white)
+        }
+    }
+
+    struct SingleJob: View {
+        @EnvironmentObject private var state: Navigation
+        public let job: Job
+        @State private var isPresented: Bool = false
+        @State private var highlighted: Bool = false
+
+        var body: some View {
+            VStack(alignment: .leading, spacing: 0) {
+                Button {
+                    self.isPresented.toggle()
+                    self.state.session.setJob(self.job)
+                } label: {
+                    HStack(alignment: .center, spacing: 8) {
+                        ZStack {
+                            Theme.base.opacity(0.6).blendMode(.softLight)
+                            Image(systemName: self.isPresented ? "minus" : "plus")
+                                .foregroundStyle(.white)
+                        }
+                        .frame(width: 30, height: 30)
+                        .cornerRadius(5)
+
+                        Text(self.job.title ?? self.job.jid.string)
+                            .font(.title3)
+                            .multilineTextAlignment(.leading)
+                        Spacer()
+                    }
+                }
+                .padding(8)
+                .buttonStyle(.plain)
+                .useDefaultHover({ inside in self.highlighted = inside})
+
+                if self.isPresented {
+                    HStack(alignment: .center, spacing: 0) {
+                        Spacer()
+                        RowAddNavLink(
+                            title: "+ Job",
+                            target: AnyView(JobCreate())
+                        )
+                        .buttonStyle(.plain)
+                    }
+                    .padding([.top, .bottom], 8)
+                    .background(Theme.base.opacity(0.6).blendMode(.softLight))
+
+                    VStack(alignment: .leading, spacing: 0) {
+                        ZStack(alignment: .topLeading) {
+                            LinearGradient(colors: [Theme.base, .clear], startPoint: .top, endPoint: .bottom)
+                                .opacity(0.6)
+                                .blendMode(.softLight)
+                                .frame(height: 50)
+                            VStack(alignment: .leading, spacing: 0) {
+                                if let tasks = self.job.tasks?.allObjects as? [LogTask] {
+                                    Tasks(job: self.job, tasks: tasks)
+                                }
+                            }
+                            .padding(.leading, 15)
+                        }
+                    }
+                }
+            }
+            .background(self.job.alive ? self.highlighted ? self.job.backgroundColor.opacity(0.9) : self.job.backgroundColor : .gray.opacity(0.8))
+            .foregroundStyle((self.job.alive ? self.job.backgroundColor : .gray).isBright() ? .black : .white)
+        }
+    }
+
+    struct Tasks: View {
+        @EnvironmentObject private var state: Navigation
+        public let job: Job
+        public let tasks: [LogTask]
+        @State private var isPresented: Bool = false
+        @State private var highlighted: Bool = false
+
+        var body: some View {
+            VStack(alignment: .leading, spacing: 0) {
+                Button {
+                    self.isPresented.toggle()
+                } label: {
+                    HStack(alignment: .center, spacing: 8) {
+                        ZStack {
+                            Theme.base.opacity(0.6).blendMode(.softLight)
+                            Image(systemName: self.isPresented ? "minus" : "plus")
+                                .foregroundStyle(.white)
+                        }
+                        .frame(width: 30, height: 30)
+                        .cornerRadius(5)
+
+                        Text("Tasks")
+                            .font(.title3)
+                            .multilineTextAlignment(.leading)
+                        Spacer()
+                    }
+                }
+                .padding(8)
+                .buttonStyle(.plain)
+                .useDefaultHover({ inside in self.highlighted = inside})
+
+                if self.isPresented {
+                    HStack(alignment: .center, spacing: 0) {
+                        Spacer()
+                        RowAddNavLink(
+                            title: "+ Task",
+                            target: AnyView(EmptyView())
+                        )
+                        .buttonStyle(.plain)
+                    }
+                    .padding([.top, .bottom], 8)
+                    .background(Theme.base.opacity(0.6).blendMode(.softLight))
+
+                    VStack(alignment: .leading, spacing: 0) {
+                        ZStack(alignment: .topLeading) {
+                            LinearGradient(colors: [Theme.base, .clear], startPoint: .top, endPoint: .bottom)
+                                .opacity(0.6)
+                                .blendMode(.softLight)
+                                .frame(height: 50)
+                            VStack(alignment: .leading, spacing: 0) {
+                                ForEach(self.tasks, id: \.objectID) { task in
+                                    if task.content != nil {
+                                        Button {
+                                            self.state.to(.taskDetail)
+                                        } label: {
+                                            Text(task.content!)
+                                        }
+                                        .buttonStyle(.plain)
+                                    }
+                                }
+                            }
+                            .padding(.leading, 15)
+                        }
+                    }
+                }
+            }
+            .background(self.job.alive ? self.highlighted ? self.job.backgroundColor.opacity(0.9) : self.job.backgroundColor : .gray.opacity(0.8))
+            .foregroundStyle((self.job.alive ? self.job.backgroundColor : .gray).isBright() ? .black : .white)
+        }
+    }
+}

--- a/DLPrototype/Views/Shared/AppSidebar/Widgets/OutlineWidget.swift
+++ b/DLPrototype/Views/Shared/AppSidebar/Widgets/OutlineWidget.swift
@@ -132,8 +132,10 @@ extension ProjectOutline {
 
         var body: some View {
             HStack(alignment: .top, spacing: 5) {
-                Image(systemName: "folder")
-                FancyTextLink(text: "[\(project.abbreviation != nil ? project.abbreviation!.uppercased() : "NOPE")] \(project.name!.capitalized)", destination: AnyView(ProjectView(project: project)), pageType: .companies, sidebar: AnyView(DefaultCompanySidebar()))
+                Image(systemName: "folder.fill")
+                    .foregroundStyle(project.backgroundColor)
+
+                FancyTextLink(text: "[\(project.abbreviation != nil ? project.abbreviation!.uppercased() : "XXX")] \(project.name!.capitalized)", destination: AnyView(ProjectView(project: project)), pageType: .companies, sidebar: AnyView(DefaultCompanySidebar()))
                     .help("Edit project: \(project.name!.capitalized)")
                 Spacer()
                 FancyButtonv2(text: "Action", action: {aboutPanelOpen.toggle()}, icon: aboutPanelOpen ? "chevron.up.square.fill" : "chevron.down.square", showLabel: false, size: .tiny, type: .clear)

--- a/DLPrototype/Views/Shared/AppSidebar/Widgets/OutlineWidget.swift
+++ b/DLPrototype/Views/Shared/AppSidebar/Widgets/OutlineWidget.swift
@@ -178,6 +178,7 @@ extension ProjectOutline {
                 HStack(spacing: 0) {
                     HStack {
                         Image(systemName: "hammer")
+                            .foregroundStyle(project.backgroundColor)
                         Text(String(jobs))
                     }
                     .help("\(jobs) Jobs")
@@ -185,6 +186,7 @@ extension ProjectOutline {
 
                     HStack {
                         Image(systemName: "note.text")
+                            .foregroundStyle(project.backgroundColor)
                         Text(String(notes))
                     }
                     .help("\(notes) Notes")
@@ -192,6 +194,7 @@ extension ProjectOutline {
 
                     HStack {
                         Image(systemName: "checklist")
+                            .foregroundStyle(project.backgroundColor)
                         Text(String(tasks))
                     }
                     .help("\(tasks) Tasks")

--- a/DLPrototype/Views/Shared/AppSidebar/Widgets/TodayInHistoryWidget.swift
+++ b/DLPrototype/Views/Shared/AppSidebar/Widgets/TodayInHistoryWidget.swift
@@ -23,49 +23,22 @@ struct TodayInHistoryWidget: View {
     @AppStorage("dashboard.maxYearsPastInHistory") public var maxYearsPastInHistory: Int = 5
 
     var body: some View {
-        VStack(alignment: .leading) {
-            VStack {
-                HStack {
-                    VStack(alignment: .leading) {
-                        FancyButton(text: "Previous day", action: prev, icon: "chevron.left", transparent: true, showLabel: false, size: .small)
-                    }
 
-                    VStack(alignment: .center) {
-                        HStack {
-                            Spacer()
-                            FancyTextLink(
-                                text: "\(selectedDate)",
-                                transparent: true,
-                                destination: AnyView(Today(defaultSelectedDate: currentDate).environmentObject(nav)),
-                                pageType: .today,
-                                sidebar: AnyView(TodaySidebar())
-                            )
-                            Spacer()
-                        }
-                    }
-
-                    VStack(alignment: .trailing) {
-                        FancyButton(text: "Next day", action: next, icon: "chevron.right", transparent: true, showLabel: false, size: .small)
-                    }
-                }
-                .frame(height: 30)
-                
-                VStack(alignment: .leading, spacing: 1) {
-                    ForEach(todayInHistory, id: \.year) { day in
-                        SidebarItem(
-                            data: day.linkLabel(),
-                            help: day.linkLabel(),
-                            icon: "arrowshape.right",
-                            orientation: .right,
-                            action: {actionTodayInHistory(day)}
-                        )
-                        .foregroundColor(day.highlight ? Color.black.opacity(0.6) : Color.white)
-                    }
+            VStack(alignment: .leading, spacing: 1) {
+                ForEach(todayInHistory, id: \.year) { day in
+                    SidebarItem(
+                        data: day.linkLabel(),
+                        help: day.linkLabel(),
+                        icon: "arrowshape.right",
+                        orientation: .right,
+                        action: {actionTodayInHistory(day)}
+                    )
+                    .foregroundColor(day.highlight ? Color.black.opacity(0.6) : Color.white)
                 }
             }
             .padding(8)
             .background(Theme.base.opacity(0.2))
-        }
+        
         .onAppear(perform: loadWidgetData)
         .onChange(of: nav.session.date) {
             loadWidgetData()

--- a/DLPrototype/Views/Shared/AppSidebar/Widgets/TodayInHistoryWidget.swift
+++ b/DLPrototype/Views/Shared/AppSidebar/Widgets/TodayInHistoryWidget.swift
@@ -67,7 +67,7 @@ struct TodayInHistoryWidget: View {
             .background(Theme.base.opacity(0.2))
         }
         .onAppear(perform: loadWidgetData)
-        .onChange(of: nav.session.date) { _ in
+        .onChange(of: nav.session.date) {
             loadWidgetData()
         }
     }

--- a/DLPrototype/Views/Shared/Fancy/FancyGenericToolbar.swift
+++ b/DLPrototype/Views/Shared/Fancy/FancyGenericToolbar.swift
@@ -80,6 +80,7 @@ struct FancyGenericToolbar: View {
                                 if buttons.count == 1 {
                                     Text(buttons.first!.helpText)
                                         .padding(.leading, 10)
+                                        .opacity(0.6)
                                 }
                             }
                         }
@@ -94,11 +95,13 @@ struct FancyGenericToolbar: View {
                         if !standalone {
                             Theme.toolbarColour
                         }
-                        
-                        VStack {
-                            ForEach(buttons, id: \ToolbarButton.id) { button in
-                                if button.id == selected && button.contents != nil {
-                                    button.contents
+
+                        ScrollView(showsIndicators: false) {
+                            VStack {
+                                ForEach(buttons, id: \ToolbarButton.id) { button in
+                                    if button.id == selected && button.contents != nil {
+                                        button.contents
+                                    }
                                 }
                             }
                         }

--- a/DLPrototype/Views/Shared/Fancy/FancyGenericToolbar.swift
+++ b/DLPrototype/Views/Shared/Fancy/FancyGenericToolbar.swift
@@ -68,19 +68,21 @@ struct FancyGenericToolbar: View {
                     ZStack(alignment: .topLeading) {
                         (location == .sidebar ? .clear : Theme.toolbarColour)
 
-                        HStack(spacing: 1) {
-                            ForEach(buttons, id: \ToolbarButton.id) { button in
-                                TabView(
-                                    button: button,
-                                    location: location,
-                                    selected: $selected,
-                                    mode: mode
-                                )
-                                
-                                if buttons.count == 1 {
-                                    Text(buttons.first!.helpText)
-                                        .padding(.leading, 10)
-                                        .opacity(0.6)
+                        ScrollView(.horizontal) {
+                            HStack(spacing: 1) {
+                                ForEach(buttons, id: \ToolbarButton.id) { button in
+                                    TabView(
+                                        button: button,
+                                        location: location,
+                                        selected: $selected,
+                                        mode: mode
+                                    )
+                                    
+                                    if buttons.count == 1 {
+                                        Text(buttons.first!.helpText)
+                                            .padding(.leading, 10)
+                                            .opacity(0.6)
+                                    }
                                 }
                             }
                         }
@@ -146,7 +148,7 @@ struct FancyGenericToolbar: View {
                         )
                         :
                         (
-                            highlighted ? Theme.base.opacity(0.2) : Theme.tabColour
+                            highlighted ? Theme.base.opacity(0.1) : Theme.tabColour
                         )
                     )
 

--- a/DLPrototype/Views/Shared/Fancy/FancyGenericToolbar.swift
+++ b/DLPrototype/Views/Shared/Fancy/FancyGenericToolbar.swift
@@ -68,7 +68,7 @@ struct FancyGenericToolbar: View {
                     ZStack(alignment: .topLeading) {
                         (location == .sidebar ? .clear : Theme.toolbarColour)
 
-                        ScrollView(.horizontal) {
+                        ScrollView(.horizontal, showsIndicators: false) {
                             HStack(spacing: 1) {
                                 ForEach(buttons, id: \ToolbarButton.id) { button in
                                     TabView(

--- a/DLPrototype/Views/Shared/Fancy/FancyStar.swift
+++ b/DLPrototype/Views/Shared/Fancy/FancyStar.swift
@@ -17,3 +17,14 @@ struct FancyStar: View {
             .shadow(color: (background.isBright() ? Color.yellow : Color.black).opacity(0.4), radius: 3)
     }
 }
+
+
+struct FancyStarv2: View {
+    var body: some View {
+        Image(systemName: "star.fill")
+            .padding(.trailing, 8)
+            .foregroundStyle(.yellow)
+            .font(.title3)
+            .shadow(color: .black.opacity(0.5), radius: 3)
+    }
+}

--- a/DLPrototype/Views/Shared/Fancy/FancyTextLink.swift
+++ b/DLPrototype/Views/Shared/Fancy/FancyTextLink.swift
@@ -10,6 +10,7 @@ import Foundation
 import SwiftUI
 
 struct FancyTextLink: View {
+    @EnvironmentObject public var nav: Navigation
     public var text: String
     public var transparent: Bool? = true
     public var showIcon: Bool? = false
@@ -18,9 +19,8 @@ struct FancyTextLink: View {
     public var bgColour: Color? = Color.black.opacity(0.2)
     public var pageType: Page = .today
     public var sidebar: AnyView? = nil
+    @State private var highlighted: Bool = false
 
-    @EnvironmentObject public var nav: Navigation
-    
     var body: some View {
         VStack {
             Button {
@@ -35,19 +35,14 @@ struct FancyTextLink: View {
                 
                 Text(text)
                     .font(Theme.font)
+                    .multilineTextAlignment(.leading)
             }
             .buttonStyle(.borderless)
             .foregroundColor(fgColour)
             .font(.title3)
             .underline()
             .background(transparent! ? Color.clear : bgColour)
-            .onHover { inside in
-                if inside {
-                    NSCursor.pointingHand.push()
-                } else {
-                    NSCursor.pop()
-                }
-            }
+            .useDefaultHover({ inside in self.highlighted = inside})
         }
     }
 }

--- a/DLPrototype/Views/Shared/SearchBar.swift
+++ b/DLPrototype/Views/Shared/SearchBar.swift
@@ -16,6 +16,7 @@ struct SearchBar: View {
     public var placeholder: String? = "Search..."
     public var onSubmit: (() -> Void)? = nil
     public var onReset: (() -> Void)? = nil
+    @FocusState private var primaryTextFieldInFocus: Bool
     // @TODO: this will remember the search text between pages, but I think instead I need some kind of search history
 //    @AppStorage("shared.searchbar") private var text: String = ""
     
@@ -23,7 +24,14 @@ struct SearchBar: View {
         GridRow {
             ZStack(alignment: .trailing) {
                 FancyTextField(placeholder: placeholder!, lineLimit: 1, onSubmit: onSubmit, disabled: disabled, text: $text)
-                
+                    .focused($primaryTextFieldInFocus)
+                    .onAppear {
+                        // thx https://www.kodeco.com/31569019-focus-management-in-swiftui-getting-started#toc-anchor-002
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+                            self.primaryTextFieldInFocus = true
+                        }
+                    }
+
                 Spacer()
                 
                 if text.count > 0 {

--- a/DLPrototype/Views/Shared/Theme.swift
+++ b/DLPrototype/Views/Shared/Theme.swift
@@ -18,7 +18,7 @@ struct Theme {
     static public var subHeaderColour: Color = headerColour.opacity(0.2)
     static public var footerColour: Color = Color.gray.opacity(0.5)
     static public var toolbarColour: Color = Color.indigo.opacity(0.2)
-    static public var tabColour: Color = Color.white.opacity(0.2)
+    static public var tabColour: Color = Color.white.opacity(0.08)
     static public var tabActiveColour: Color = headerColour
     static public var rowStatusGreen: Color = Color.green.opacity(0.2)
     static public var rowStatusYellow: Color = Color.yellow.opacity(0.2)

--- a/DLPrototype/Views/Shared/Theme.swift
+++ b/DLPrototype/Views/Shared/Theme.swift
@@ -28,8 +28,8 @@ struct Theme {
     
     static public let font: Font = .system(.body, design: .default)
     static public let fontTextField: Font = .system(.body, design: .monospaced)
-    static public let fontTitle: Font = .system(.title, design: .monospaced)
-    static public let fontSubTitle: Font = .system(.title3, design: .monospaced)
+    static public let fontTitle: Font = .system(.title)
+    static public let fontSubTitle: Font = .system(.title3)
     static public let fontCaption: Font = .system(.caption, design: .monospaced)
 
     static public let cYellow: Color = .init(.sRGB, red: 0.34, green: 0.32, blue: 0.22, opacity: 1)


### PR DESCRIPTION
The one widget to rule them all (or most of them, anyways). Similar to the `HierarchyExplorer` view on iOS, this allows you to see all the resources under one easy to navigate list.

![Screenshot 2024-10-02 at 18 38 46](https://github.com/user-attachments/assets/0d4884f1-d30a-4b83-9a21-133a961b2da1)

This also includes improvements to search so you can find companies, people, terms and definitions.