### PR TITLE
Fix bug that prevents notes from saving

### DIFF
--- a/KlockWork/Views/Entities/Jobs/JobView.swift
+++ b/KlockWork/Views/Entities/Jobs/JobView.swift
@@ -76,12 +76,12 @@ struct JobView: View {
                 PersistenceController.shared.save()
             }
         }
-        .onChange(of: alive) { status in
-            job.alive = status
+        .onChange(of: self.alive) {
+            job.alive = self.alive
             PersistenceController.shared.save()
         }
-        .onChange(of: nav.saved) { status in
-            if status {
+        .onChange(of: self.nav.saved) {
+            if self.nav.saved {
                 self.update()
             }
         }

--- a/KlockWork/Views/Entities/Notes/NoteCreate.swift
+++ b/KlockWork/Views/Entities/Notes/NoteCreate.swift
@@ -124,7 +124,6 @@ extension NoteCreate {
             
             // the last note you interacted with
             self.state.session.note = note
-            self.state.save()
         } else {
             print("[error][note.create] A title is required to save")
         }

--- a/KlockWork/Views/Entities/Notes/NoteDashboard.swift
+++ b/KlockWork/Views/Entities/Notes/NoteDashboard.swift
@@ -67,7 +67,7 @@ struct NoteDashboard: View {
                     UI.BoundSearchBar(
                         text: $searchText,
                         disabled: false,
-                        placeholder: notes.count > 1 ? "Search \(self.notes.count) notes" : "Search 1 note"
+                        placeholder: notes.count > 1 ? "Filter \(self.notes.count) notes" : "Filter 1 note"
                     )
                     FancyDivider(height: 20)
 

--- a/KlockWork/Views/Entities/Notes/NoteFormWidget.swift
+++ b/KlockWork/Views/Entities/Notes/NoteFormWidget.swift
@@ -87,8 +87,8 @@ struct NoteFormWidget: View {
                 FancySimpleButton(
                     text: note == nil ? "Create" : "Save",
                     action: {nav.save()},
-                    type: nav.forms.note.job == nil ? .error : .primary,
-                    href: note == nil ? .notes : nil
+                    type: nav.forms.note.job == nil ? .error : .primary
+//                    href: note == nil ? .notes : nil
                 )
                 .keyboardShortcut("s", modifiers: .command)
                 .disabled(nav.forms.note.job == nil)
@@ -438,6 +438,8 @@ extension NoteFormWidget {
     private func actionOnAppear() -> Void {
         if let stored = self.nav.session.note {
             self.note = stored
+            self.nav.session.note = nil
+            self.nav.forms.note.job = stored.mJob
             self.mode = .update
 
             let versions = stored.versions?.allObjects as! [NoteVersion]
@@ -448,8 +450,6 @@ extension NoteFormWidget {
 
         if let job = nav.session.job {
             nav.forms.note.job = job
-        } else if let n = note {
-            nav.forms.note.job = n.mJob
         }
 
         nav.forms.note.version = currentVersion


### PR DESCRIPTION
Sometimes notes wouldn't save. Turned out to be caused by changing views too fast.