### PR TITLE
Add jobs representing upcoming tasks to planning view if no plan exists

### DIFF
--- a/KWCore/Sources/Query/CoreDataTasks.swift
+++ b/KWCore/Sources/Query/CoreDataTasks.swift
@@ -384,6 +384,24 @@ public class CoreDataTasks {
 
         return query(predicate, sort)
     }
+    
+    /// Find jobs for the tasks which are due today. Used to overwrite AppState.planning.jobs
+    /// - Parameter date: Date
+    /// - Returns: Set<Job>
+    public func jobsForTasksDueToday(_ date: Date = Date.now) -> Set<Job> {
+        let suggested = CoreDataTasks(moc: self.moc!).dueToday(date)
+        var sJobs: Set<Job> = []
+
+        if !suggested.isEmpty {
+            for task in suggested {
+                if let job = task.owner {
+                    sJobs.insert(job)
+                }
+            }
+        }
+
+        return sJobs
+    }
 
     /// Find tasks due today
     /// - Returns: Array<LogTask>

--- a/KlockWork/Views/Planning/Tabs/Planning.Today.swift
+++ b/KlockWork/Views/Planning/Tabs/Planning.Today.swift
@@ -47,5 +47,9 @@ extension Planning.Today {
     /// - Returns: Void
     private func actionOnAppear() -> Void {
         self.jobs = self.nav.planning.jobs
+
+        if self.nav.planning.jobs.isEmpty {
+            self.jobs = CoreDataTasks(moc: self.nav.moc).jobsForTasksDueToday()
+        }
     }
 }


### PR DESCRIPTION
This has been implemented on iOS since the beginning and it has really encouraged me plan out my day.