### PR TITLE
Pre-release UX/UI updates

### DIFF
--- a/KWCore/Sources/Query/CoreDataJob.swift
+++ b/KWCore/Sources/Query/CoreDataJob.swift
@@ -527,7 +527,37 @@ public class CoreDataJob: ObservableObject {
 
         return count(predicate)
     }
-    
+
+    /// Get links from jobs created or updated on a given day
+    /// - Parameter start: Optional(Date)
+    /// - Parameter end: Optional(Date)
+    /// - Returns: Array<Activity>
+    public func getLinksFromJobs(start: Date?, end: Date?) async -> [Activity] {
+        let jobs = self.inRange(
+            start: start,
+            end: end
+        )
+        var activities: [Activity] = []
+
+        for job in jobs {
+            if let uri = job.uri {
+                if uri.absoluteString != "https://" {
+                    activities.append(
+                        Activity(
+                            name: uri.absoluteString,
+                            page: .dashboard, //self.state.parent ??
+                            type: .activity,
+                            job: job,
+                            url: uri.absoluteURL
+                        )
+                    )
+                }
+            }
+        }
+
+        return activities
+    }
+
     /// Create a new Job
     /// - Parameters:
     ///   - alive: Bool

--- a/KWCore/Sources/UI/WidgetLibrary/WidgetLibrary.Blocks.swift
+++ b/KWCore/Sources/UI/WidgetLibrary/WidgetLibrary.Blocks.swift
@@ -65,7 +65,7 @@ extension WidgetLibrary.UI {
                     .frame(height: 65)
 
                     ZStack(alignment: .center) {
-                        (self.isHighlighted ? Color.yellow : Theme.textBackground)
+                        (self.isHighlighted ? self.state.theme.tint : Theme.textBackground)
                         VStack(alignment: .center, spacing: 0) {
                             Text(self.text)
                                 .font(.system(.title3, design: .monospaced))

--- a/KWCore/Sources/UI/WidgetLibrary/WidgetLibrary.UI.Buttons.swift
+++ b/KWCore/Sources/UI/WidgetLibrary/WidgetLibrary.UI.Buttons.swift
@@ -381,7 +381,7 @@ extension WidgetLibrary.UI {
                     action: {self.commandLineMode.toggle() ; self.onAction?()},
                     icon: self.commandLineMode ? "apple.terminal.fill" : "apple.terminal",
                     iconWhenHighlighted: self.commandLineMode ? "apple.terminal" : "apple.terminal.fill",
-                    iconFgColour: self.commandLineMode ? self.state.theme.tint : .white,
+                    iconFgColour: self.commandLineMode ? self.state.theme.tint : .gray,
                     showLabel: false,
                     size: .small,
                     type: .clear,

--- a/KWCore/Sources/UI/WidgetLibrary/WidgetLibrary.UI.Buttons.swift
+++ b/KWCore/Sources/UI/WidgetLibrary/WidgetLibrary.UI.Buttons.swift
@@ -565,11 +565,14 @@ extension WidgetLibrary.UI {
         // MARK: Buttons.FooterActivity
         struct FooterActivity: View {
             @EnvironmentObject private var state: Navigation
-            var count: Int
+
+            var start: Date?
+            var end: Date?
             var label: String
             var icon: String
             @AppStorage("widgetlibrary.ui.appfooter.isMinimized") private var isMinimized: Bool = false
             @State private var isHighlighted: Bool = false
+            @State private var count: Int = 0
 
             var body: some View {
                 Button {
@@ -592,6 +595,22 @@ extension WidgetLibrary.UI {
                 .buttonStyle(.plain)
                 .useDefaultHover({ hover in self.isHighlighted = hover })
                 .help("\(self.count) \(self.label) on \(self.state.session.dateFormatted("MMMM dd, yyyy"))")
+                .onAppear(perform: self.actionOnAppear)
+            }
+        }
+    }
+}
+
+extension WidgetLibrary.UI.Buttons.FooterActivity {
+    /// Onload handler. Sets view state.
+    /// - Returns: Void
+    private func actionOnAppear() -> Void {
+        Task {
+            if let start = self.start {
+                if let end = self.end {
+                    let fromRecords = await CoreDataRecords(moc: self.state.moc).getLinksFromRecords(start: start, end: end)
+                    self.count += fromRecords.count
+                }
             }
         }
     }

--- a/KWCore/Sources/UI/WidgetLibrary/WidgetLibrary.UI.EntityCalendar.swift
+++ b/KWCore/Sources/UI/WidgetLibrary/WidgetLibrary.UI.EntityCalendar.swift
@@ -290,6 +290,7 @@ extension WidgetLibrary.UI {
         /// An individual calendar day "tile"
         struct Day: View, Identifiable {
             @EnvironmentObject private var state: Navigation
+            @AppStorage("general.appTintChoice") private var appTintChoice: Int = 0
             public let id: UUID = UUID()
             public var date: Date
             public var dayNumber: Int = 0
@@ -338,6 +339,7 @@ extension WidgetLibrary.UI {
                 .foregroundColor(self.fgColour)
                 .clipShape(.rect(cornerRadius: 6))
                 .onAppear(perform: self.actionOnAppear)
+                .onChange(of: self.appTintChoice) { self.actionOnAppear() }
                 .contextMenu {
                     Button {
                         self.state.session.date = self.date

--- a/KWCore/Sources/UI/WidgetLibrary/WidgetLibrary.UI.Navigator.swift
+++ b/KWCore/Sources/UI/WidgetLibrary/WidgetLibrary.UI.Navigator.swift
@@ -400,7 +400,7 @@ extension WidgetLibrary.UI.Navigator {
                         }
                         Image(systemName: self.isPresented ? "star.fill" : self.isHighlighted ? "folder.fill" : "folder")
                             // @TODO: create a ShapeStyle for this
-                            .foregroundStyle(self.isPresented ? .yellow : self.viewModeIndex == 1 ? self.colour.isBright() ? Theme.base : .white : self.colour)
+                            .foregroundStyle(self.isPresented ? self.state.theme.tint : self.viewModeIndex == 1 ? self.colour.isBright() ? Theme.base : .white : self.colour)
                     }
                     .frame(width: 30, height: 30)
                     .cornerRadius(5)

--- a/KWCore/Sources/UI/WidgetLibrary/WidgetLibrary.UI.UnifiedSidebar.swift
+++ b/KWCore/Sources/UI/WidgetLibrary/WidgetLibrary.UI.UnifiedSidebar.swift
@@ -562,7 +562,7 @@ extension WidgetLibrary.UI {
                             ZStack(alignment: .center) {
                                 Theme.base.opacity(0.6).blendMode(.softLight)
                                 Image(systemName: self.active ? "star.fill" : self.isPresented ? "minus" : "plus")
-                                    .foregroundStyle(self.active ? self.state.theme.tint : .white)
+                                    .foregroundStyle(self.active ? .yellow : .white)
                             }
                             .frame(width: 30, height: 30)
                             .cornerRadius(5)

--- a/KWCore/Sources/UI/WidgetLibrary/WidgetLibrary.UI.UnifiedSidebar.swift
+++ b/KWCore/Sources/UI/WidgetLibrary/WidgetLibrary.UI.UnifiedSidebar.swift
@@ -562,7 +562,7 @@ extension WidgetLibrary.UI {
                             ZStack(alignment: .center) {
                                 Theme.base.opacity(0.6).blendMode(.softLight)
                                 Image(systemName: self.active ? "star.fill" : self.isPresented ? "minus" : "plus")
-                                    .foregroundStyle(self.active ? .yellow : .white)
+                                    .foregroundStyle(self.active ? self.state.theme.tint : .white)
                             }
                             .frame(width: 30, height: 30)
                             .cornerRadius(5)

--- a/KWCore/Sources/UI/WidgetLibrary/WidgetLibrary.UI.swift
+++ b/KWCore/Sources/UI/WidgetLibrary/WidgetLibrary.UI.swift
@@ -378,7 +378,7 @@ extension WidgetLibrary {
                                     switch self.activity.source {
                                     case is NoteVersion:
                                         let entity = self.activity.source as? NoteVersion
-                                        Text("Found in note \"\(entity?.note?.title ?? "Error: Note not found")\" at \(DateHelper.todayShort(entity?.created ?? Date.now, format: "HH:mm"))")
+                                        Text("Found in note \"\(entity?.note?.title ?? "Error: Note not found")\" on \(DateHelper.todayShort(entity?.created ?? Date.now, format: "MMMM dd, yyyy HH:mm"))")
                                             .foregroundStyle(.gray)
                                         Spacer()
                                         UI.Buttons.SmallOpen(callback: {
@@ -389,7 +389,7 @@ extension WidgetLibrary {
                                         })
                                     case is LogRecord:
                                         let entity = self.activity.source as? LogRecord
-                                        Text("Found in record \"\(entity?.message ?? "Error: Record not found")\" at \(DateHelper.todayShort(entity?.timestamp ?? Date.now, format: "HH:mm"))")
+                                        Text("Found in record \"\(entity?.message ?? "Error: Record not found")\" on \(DateHelper.todayShort(entity?.timestamp ?? Date.now, format: "MMMM dd, yyyy HH:mm"))")
                                             .foregroundStyle(.gray)
                                         Spacer()
                                         UI.Buttons.SmallOpen(callback: {

--- a/KWCore/Sources/UI/WidgetLibrary/WidgetLibrary.UI.swift
+++ b/KWCore/Sources/UI/WidgetLibrary/WidgetLibrary.UI.swift
@@ -421,7 +421,7 @@ extension WidgetLibrary {
                     .contextMenu { ContextMenu(activity: self.activity) }
                     .background(.white.opacity(self.isHighlighted ? 0.07 : 0.03))
                     .clipShape(.rect(cornerRadius: 5))
-                    .help(self.isLinkOnline ? self.activity.help : "Error: The website appears to be down.")
+                    .help(self.isLinkOnline ? self.activity.help : "Error: \(self.name) is down")
                 }
             }
 

--- a/KWCore/Sources/UI/WidgetLibrary/WidgetLibrary.UI.swift
+++ b/KWCore/Sources/UI/WidgetLibrary/WidgetLibrary.UI.swift
@@ -377,7 +377,8 @@ extension WidgetLibrary {
                                 HStack(alignment: .top) {
                                     switch self.activity.source {
                                     case is NoteVersion:
-                                        Text("Found in note \"\((self.activity.source as? NoteVersion)?.note?.title ?? "Error: Note not found")\"")
+                                        let entity = self.activity.source as? NoteVersion
+                                        Text("Found in note \"\(entity?.note?.title ?? "Error: Note not found")\" at \(DateHelper.todayShort(entity?.created ?? Date.now, format: "HH:mm"))")
                                             .foregroundStyle(.gray)
                                         Spacer()
                                         UI.Buttons.SmallOpen(callback: {
@@ -387,7 +388,8 @@ extension WidgetLibrary {
                                             }
                                         })
                                     case is LogRecord:
-                                        Text("Found in record \"\((self.activity.source as? LogRecord)?.message ?? "Error: Record not found")\"")
+                                        let entity = self.activity.source as? LogRecord
+                                        Text("Found in record \"\(entity?.message ?? "Error: Record not found")\" at \(DateHelper.todayShort(entity?.timestamp ?? Date.now, format: "HH:mm"))")
                                             .foregroundStyle(.gray)
                                         Spacer()
                                         UI.Buttons.SmallOpen(callback: {

--- a/KWCore/Sources/UI/WidgetLibrary/WidgetLibrary.UI.swift
+++ b/KWCore/Sources/UI/WidgetLibrary/WidgetLibrary.UI.swift
@@ -1007,7 +1007,7 @@ extension WidgetLibrary {
                         UI.ListLinkTitle(text: "Suggested links from \(self.format == nil ? "period" : self.state.session.dateFormatted(self.format!))")
                         UI.ActivityLinks(start: self.start, end: self.end)
                     } else {
-                        UI.Buttons.FooterActivity(count: self.activities.count, label: "Links", icon: "link")
+                        UI.Buttons.FooterActivity(start: self.start, end: self.end, label: "Links", icon: "link")
                     }
                     Spacer()
                 }

--- a/KWCore/Sources/UI/WidgetLibrary/WidgetLibrary.UI.swift
+++ b/KWCore/Sources/UI/WidgetLibrary/WidgetLibrary.UI.swift
@@ -1970,13 +1970,16 @@ extension WidgetLibrary {
                 switch self.entity {
                 case is Company:
                     Button {
+                        self.state.session.job = nil
+                        self.state.session.project = nil
                         self.state.session.company = self.entity as? Company
-                        self.state.to(.companyDetail)
                     } label: {
                         if let entity = self.entity as? Company {
                             entity.linkRowView
                                 .underline(self.isHighlighted)
                                 .contextMenu {
+                                    Button("Edit...") { self.state.to(.companyDetail) }
+                                    Divider()
                                     Button("Inspect", action: {
                                         let entity = self.entity as? Company
                                         self.state.session.search.inspectingEntity = entity
@@ -1990,14 +1993,16 @@ extension WidgetLibrary {
                     .help("Open")
                 case is Project:
                     Button {
+                        self.state.session.job = nil
                         self.state.session.project = self.entity as? Project
                         self.state.session.company = self.state.session.project?.company
-                        self.state.to(.projectDetail)
                     } label: {
                         if let entity = self.entity as? Project {
                             entity.linkRowView
                                 .underline(self.isHighlighted)
                                 .contextMenu {
+                                    Button("Edit...") { self.state.to(.projectDetail) }
+                                    Divider()
                                     Button("Inspect", action: {
                                         let entity = self.entity as? Project
                                         self.state.session.search.inspectingEntity = entity
@@ -2014,12 +2019,13 @@ extension WidgetLibrary {
                         self.state.session.job = self.entity as? Job
                         self.state.session.project = self.state.session.job?.project
                         self.state.session.company = self.state.session.project?.company
-                        self.state.to(.jobs)
                     } label: {
                         if let entity = self.entity as? Job {
                             entity.linkRowView
                                 .underline(self.isHighlighted)
                                 .contextMenu {
+                                    Button("Edit...") { self.state.to(.jobs) }
+                                    Divider()
                                     Button("Inspect", action: {
                                         let entity = self.entity as? Job
                                         self.state.session.search.inspectingEntity = entity

--- a/KWCore/Sources/UI/WidgetLibrary/WidgetLibrary.UI.swift
+++ b/KWCore/Sources/UI/WidgetLibrary/WidgetLibrary.UI.swift
@@ -274,8 +274,8 @@ extension WidgetLibrary {
                         HStack(alignment: .center) {
                             ZStack {
                                 RoundedRectangle(cornerRadius: 20)
-                                    .strokeBorder(self.isToday ? .yellow.opacity(0.6) : .gray, lineWidth: 1)
-                                    .fill(self.isToday ? .yellow.opacity(self.isHighlighted ? 0.8 : 0.7) : .gray.opacity(self.isHighlighted ? 0.8 : 0.7))
+                                    .strokeBorder(self.isToday ? self.state.theme.tint.opacity(0.6) : .gray, lineWidth: 1)
+                                    .fill(self.isToday ? self.state.theme.tint.opacity(self.isHighlighted ? 0.8 : 0.7) : .gray.opacity(self.isHighlighted ? 0.8 : 0.7))
                                 if !self.showDateOverlay {
                                     HStack {
                                         Image(systemName: "calendar")
@@ -586,7 +586,7 @@ extension WidgetLibrary {
                             .frame(height: 65)
 
                             ZStack(alignment: .center) {
-                                (self.isHighlighted ? Color.yellow : Theme.textBackground)
+                                (self.isHighlighted ? self.state.theme.tint : Theme.textBackground)
                                 VStack(alignment: .center, spacing: 0) {
                                     Text(String(self.count))
                                         .font(.system(.title3, design: .monospaced))
@@ -1480,6 +1480,7 @@ extension WidgetLibrary {
 
         // MARK: Toggle
         struct Toggle: View {
+            @EnvironmentObject private var state: Navigation
             public var title: String? = nil
             @Binding public var isOn: Bool
             public var eType: PageConfiguration.EntityType? = .BruceWillis
@@ -1502,7 +1503,7 @@ extension WidgetLibrary {
                             (self.isOn ? self.eType?.selectedIcon : self.eType?.icon)
                         }
                     }
-                    .foregroundStyle(self.isOn ? .yellow : .gray)
+                    .foregroundStyle(self.isOn ? self.state.theme.tint : .gray)
                     .padding(3)
                 }
                 .help(self.title ?? self.eType?.label ?? "")

--- a/KlockWork/DLPrototype.entitlements
+++ b/KlockWork/DLPrototype.entitlements
@@ -12,6 +12,8 @@
 	</array>
 	<key>com.apple.security.app-sandbox</key>
 	<true/>
+	<key>com.apple.security.network.client</key>
+	<true/>
 	<key>com.apple.security.personal-information.calendars</key>
 	<true/>
 </dict>

--- a/KlockWork/DLPrototype.swift
+++ b/KlockWork/DLPrototype.swift
@@ -106,7 +106,6 @@ struct DLPrototype: App {
         case 4: self.nav.theme.tint = .red
         case 5: self.nav.theme.tint = .orange
         case 7: self.nav.theme.tint = .green
-        case 8: self.nav.theme.tint = .gray
         default:
             self.nav.theme.tint = .yellow
         }

--- a/KlockWork/DLPrototype.swift
+++ b/KlockWork/DLPrototype.swift
@@ -18,6 +18,7 @@ typealias EType = PageConfiguration.EntityType
 struct DLPrototype: App {
     private let persistenceController = PersistenceController.shared
     @AppStorage("notifications.interval") private var notificationInterval: Int = 0
+    @AppStorage("general.appTintChoice") private var appTintChoice: Int = 0
     @StateObject public var updater: ViewUpdater = ViewUpdater()
     @StateObject public var nav: Navigation = Navigation()
     @State private var searching: Bool = false
@@ -97,6 +98,18 @@ struct DLPrototype: App {
         let appName = Bundle.main.infoDictionary?["CFBundleDisplayName"] as? String
         nav.title = "\(appName ?? "KlockWork")"
         nav.session.plan = CoreDataPlan(moc: persistenceController.container.viewContext).forDate(nav.session.date).first
+
+        switch self.appTintChoice {
+        case 1: self.nav.theme.tint = .blue
+        case 2: self.nav.theme.tint = .purple
+        case 3: self.nav.theme.tint = .pink
+        case 4: self.nav.theme.tint = .red
+        case 5: self.nav.theme.tint = .orange
+        case 7: self.nav.theme.tint = .green
+        case 8: self.nav.theme.tint = .gray
+        default:
+            self.nav.theme.tint = .yellow
+        }
 
         if let plan = nav.session.plan {
             nav.planning.jobs = plan.jobs as! Set<Job>

--- a/KlockWork/Views/Dashboard/DayInHistory.swift
+++ b/KlockWork/Views/Dashboard/DayInHistory.swift
@@ -50,7 +50,7 @@ struct DayInHistory: View {
                 }
             )
         )
-        .background(self.isToday ? .yellow.opacity(0.5) : self.highlight ? Theme.base.opacity(0.3) : Theme.cPurple)
+        .background(self.isToday ? self.state.theme.tint.opacity(0.5) : self.highlight ? Theme.base.opacity(0.3) : Theme.cPurple)
         .foregroundStyle(self.highlight ? Theme.lightWhite : .white)
     }
 }

--- a/KlockWork/Views/Entities/Companies/CompanyBlock.swift
+++ b/KlockWork/Views/Entities/Companies/CompanyBlock.swift
@@ -10,7 +10,6 @@ import SwiftUI
 import KWCore
 
 struct CompanyBlock: View {
-    typealias UI = WidgetLibrary.UI
     @EnvironmentObject public var nav: Navigation
     public var company: Company
     @State private var highlighted: Bool = false
@@ -31,7 +30,7 @@ struct CompanyBlock: View {
                     VStack(alignment: .leading, spacing: 10) {
                         HStack(alignment: .top) {
                             Image(systemName: self.highlighted ? "building.2.crop.circle.fill" : "building.2.crop.circle")
-                                .foregroundStyle(self.company.isDefault ? .yellow : self.highlighted ? company.backgroundColor.opacity(1) : company.backgroundColor.opacity(0.5))
+                                .foregroundStyle(self.company.isDefault ? self.nav.theme.tint : self.highlighted ? company.backgroundColor.opacity(1) : company.backgroundColor.opacity(0.5))
                                 .font(.system(size: 60))
                             VStack(alignment: .leading) {
                                 Text(company.name ?? "_COMPANY_NAME")

--- a/KlockWork/Views/Entities/Projects/ProjectBlock.swift
+++ b/KlockWork/Views/Entities/Projects/ProjectBlock.swift
@@ -10,7 +10,6 @@ import SwiftUI
 import KWCore
 
 struct ProjectBlock: View {
-    typealias UI = WidgetLibrary.UI
     @EnvironmentObject public var state: Navigation
     public var project: Project
     @State private var highlighted: Bool = false
@@ -30,7 +29,7 @@ struct ProjectBlock: View {
                     VStack(alignment: .leading, spacing: 10) {
                         HStack(alignment: .top) {
                             Image(systemName: self.highlighted ? "folder.fill" : "folder")
-                                .foregroundStyle(self.project.company?.isDefault ?? false ? .yellow : self.highlighted ? project.backgroundColor.opacity(1) : project.backgroundColor.opacity(0.5))
+                                .foregroundStyle(self.project.company?.isDefault ?? false ? self.state.theme.tint : self.highlighted ? project.backgroundColor.opacity(1) : project.backgroundColor.opacity(0.5))
                                 .font(.system(size: 60))
                             VStack(alignment: .leading) {
                                 Text(project.name ?? "_COMPANY_NAME")

--- a/KlockWork/Views/Entities/Tasks/Column.swift
+++ b/KlockWork/Views/Entities/Tasks/Column.swift
@@ -133,7 +133,7 @@ struct Column: View {
     @ViewBuilder private var Index: some View {
         ZStack(alignment: .center) {
             RoundedRectangle(cornerRadius: 10, style: .continuous)
-                .fill(self.job == self.nav.session.job ? .yellow : Theme.cPurple.opacity(0.8))
+                .fill(self.job == self.nav.session.job ? self.nav.theme.tint : Theme.cPurple.opacity(0.8))
                 .frame(height: 23)
             Text(self.text)
                 .opacity(0.5)

--- a/KlockWork/Views/Entities/Today/Today.swift
+++ b/KlockWork/Views/Entities/Today/Today.swift
@@ -9,13 +9,8 @@ import SwiftUI
 import KWCore
 
 struct Today: View {
-    public var defaultSelectedDate: Date? = nil
-    private let page: PageConfiguration.AppPage = .today
-    private var twoCol: [GridItem] { Array(repeating: .init(.flexible(minimum: 100)), count: 2) }
-
+    @EnvironmentObject public var state: Navigation
     @AppStorage("today.commandLineMode") private var commandLineMode: Bool = false
-
-    @EnvironmentObject public var nav: Navigation
 
     var body: some View {
         VStack(alignment: .leading) {
@@ -28,7 +23,10 @@ struct Today: View {
                         LogTable()
                     }
                     .padding()
-                    UI.AppFooter()
+                    UI.AppFooter(
+                        start: self.state.session.date.startOfDay,
+                        end: self.state.session.date.endOfDay
+                    )
                 }
             }
         }

--- a/KlockWork/Views/Explore/Explore.swift
+++ b/KlockWork/Views/Explore/Explore.swift
@@ -35,8 +35,8 @@ struct Explore: View {
     }
 }
 
-struct Activity: Identifiable, Equatable {
-    var id: UUID = UUID()
+public struct Activity: Identifiable, Equatable {
+    public var id: UUID = UUID()
     var name: String
     var help: String = ""
     var page: Page

--- a/KlockWork/Views/Settings/Tabs/GeneralSettings.swift
+++ b/KlockWork/Views/Settings/Tabs/GeneralSettings.swift
@@ -72,7 +72,6 @@ struct GeneralSettings: View {
                     case 4: self.state.theme.tint = Color.red
                     case 5: self.state.theme.tint = Color.orange
                     case 7: self.state.theme.tint = Color.green
-                    case 8: self.state.theme.tint = Color.gray
                     default:
                         self.state.theme.tint = Color.yellow
                     }

--- a/KlockWork/Views/Settings/Tabs/GeneralSettings.swift
+++ b/KlockWork/Views/Settings/Tabs/GeneralSettings.swift
@@ -20,6 +20,7 @@ struct GeneralSettings: View {
     @AppStorage("general.showSessionInspector") public var showSessionInspector: Bool = false
     @AppStorage("general.spotlightIndex") public var spotlightIndex: Bool = false
     @AppStorage("general.columns") private var columns: Int = 3
+    @AppStorage("general.shouldCheckLinkStatus") private var shouldCheckLinkStatus: Bool = false
 
     var body: some View {
         Form {
@@ -58,6 +59,8 @@ struct GeneralSettings: View {
                     Text("5").tag(5)
                 }
             }
+
+            Toggle("Check if links are online", isOn: $shouldCheckLinkStatus)
 
             Group {
                 Text("Defaults")

--- a/KlockWork/Views/Settings/Tabs/GeneralSettings.swift
+++ b/KlockWork/Views/Settings/Tabs/GeneralSettings.swift
@@ -11,6 +11,7 @@ import KWCore
 import CoreSpotlight
 
 struct GeneralSettings: View {
+    @EnvironmentObject private var state: Navigation
     @AppStorage("tigerStriped") private var tigerStriped: Bool = false
     @AppStorage("showExperimentalFeatures") private var showExperimentalFeatures: Bool = false
     @AppStorage("enableAutoCorrection") public var enableAutoCorrection: Bool = false
@@ -21,6 +22,7 @@ struct GeneralSettings: View {
     @AppStorage("general.spotlightIndex") public var spotlightIndex: Bool = false
     @AppStorage("general.columns") private var columns: Int = 3
     @AppStorage("general.shouldCheckLinkStatus") private var shouldCheckLinkStatus: Bool = false
+    @AppStorage("general.appTintChoice") private var appTintChoice: Int = 0
 
     var body: some View {
         Form {
@@ -50,6 +52,32 @@ struct GeneralSettings: View {
 //                Text("External services")
 //                Toggle("Spotlight (data is NOT shared with Apple)", isOn: $spotlightIndex)
 //            }
+
+            Group {
+                Picker("App tint colour", selection: $appTintChoice) {
+                    Text("Blue").tag(1)
+                    Text("Purple").tag(2)
+                    Text("Pink").tag(3)
+                    Text("Red").tag(4)
+                    Text("Orange").tag(5)
+                    Text("Yellow").tag(6)
+                    Text("Green").tag(7)
+                    Text("Graphite").tag(8)
+                }
+                .onChange(of: self.appTintChoice) {
+                    switch self.appTintChoice {
+                    case 1: self.state.theme.tint = Color.blue
+                    case 2: self.state.theme.tint = Color.purple
+                    case 3: self.state.theme.tint = Color.pink
+                    case 4: self.state.theme.tint = Color.red
+                    case 5: self.state.theme.tint = Color.orange
+                    case 7: self.state.theme.tint = Color.green
+                    case 8: self.state.theme.tint = Color.gray
+                    default:
+                        self.state.theme.tint = Color.yellow
+                    }
+                }
+            }
 
             Group {
                 Picker("Number of columns to display", selection: $columns) {

--- a/KlockWork/Views/Shared/AppSidebar/SidebarButton.swift
+++ b/KlockWork/Views/Shared/AppSidebar/SidebarButton.swift
@@ -89,7 +89,7 @@ struct SidebarButton: View, Identifiable {
                                 }
                             }
                         //                        .foregroundStyle(nav.session.job != nil ? nav.session.job!.backgroundColor : isDatePickerPresented && nav.parent == pageType ? .black : highlighted ? .white : .white.opacity(0.8))
-                            .foregroundStyle(isDatePickerPresented && nav.parent == pageType ? Theme.base : highlighted ? .white : .white.opacity(0.8))
+                            .foregroundStyle(self.highlighted ? .white : .white.opacity(0.8))
                     }
                 case .companies:
                     HStack(alignment: .top, spacing: 0) {
@@ -98,7 +98,7 @@ struct SidebarButton: View, Identifiable {
                         }
                         button.frame(width: 50, height: 50)
                         //                        .foregroundStyle(nav.session.job != nil ? nav.session.job!.backgroundColor : isDatePickerPresented && nav.parent == pageType ? .black : highlighted ? .white : .white.opacity(0.8))
-                            .foregroundStyle(isDatePickerPresented && nav.parent == pageType ? Theme.base : highlighted ? .white : .white.opacity(0.8))
+                            .foregroundStyle(self.highlighted ? self.nav.theme.tint : .white.opacity(0.8))
                     }
                 case .projects:
                     HStack(alignment: .top, spacing: 0) {
@@ -107,7 +107,7 @@ struct SidebarButton: View, Identifiable {
                         }
                         button.frame(width: 50, height: 50)
                         //                        .foregroundStyle(nav.session.job != nil ? nav.session.job!.backgroundColor : isDatePickerPresented && nav.parent == pageType ? .black : highlighted ? .white : .white.opacity(0.8))
-                            .foregroundStyle(isDatePickerPresented && nav.parent == pageType ? Theme.base : highlighted ? .white : .white.opacity(0.8))
+                            .foregroundStyle(self.highlighted ? self.nav.theme.tint : .white.opacity(0.8))
                     }
                 default: button.frame(width: 50, height: 50)
                 }
@@ -147,11 +147,15 @@ struct SidebarButton: View, Identifiable {
                 }
 
                 if let img = self.iconAsImage {
-                    img.font(.title).symbolRenderingMode(.hierarchical)
+                    img
+                        .font(.title)
+                        .symbolRenderingMode(.hierarchical)
+                        .foregroundStyle(self.nav.parent == self.pageType ? self.nav.theme.tint : .white)
                 } else {
                     Image(systemName: isDatePickerPresented && nav.parent == pageType ? "xmark" : (altMode != nil ? (altMode!.condition ? altMode!.icon : icon!) : icon!))
                         .font(.title)
                         .symbolRenderingMode(.hierarchical)
+                        .foregroundStyle(self.nav.parent == self.pageType ? self.nav.theme.tint : .white)
                 }
 
             }
@@ -201,11 +205,15 @@ struct SidebarButton: View, Identifiable {
                 }
 
                 if let img = self.iconAsImage {
-                    img.font(.title).symbolRenderingMode(.hierarchical)
-                } else {
-                    Image(systemName: isDatePickerPresented && nav.parent == pageType ? "xmark" : (altMode != nil ? (altMode!.condition ? altMode!.icon : icon!) : icon!))
+                    img
                         .font(.title)
                         .symbolRenderingMode(.hierarchical)
+                        .foregroundStyle(self.nav.parent == self.pageType ? self.nav.theme.tint : .white)
+                } else {
+                    Image(systemName: altMode != nil ? (altMode!.condition ? altMode!.icon : icon!) : icon!)
+                        .font(.title)
+                        .symbolRenderingMode(.hierarchical)
+                        .foregroundStyle(self.nav.parent == self.pageType ? self.nav.theme.tint : .white)
                 }
             }
         })

--- a/KlockWork/Views/Shared/AppSidebar/Widgets/DateSelectorWidget.swift
+++ b/KlockWork/Views/Shared/AppSidebar/Widgets/DateSelectorWidget.swift
@@ -74,7 +74,7 @@ struct DateSelectorWidget: View {
                 .padding(.top, 15)
             }
             .padding(10)
-            .background(areSameDate(nav.session.date, Date()) ? .yellow.opacity(0.8) : .white.opacity(0.4))
+            .background(areSameDate(nav.session.date, Date()) ? self.nav.theme.tint.opacity(0.8) : .white.opacity(0.4))
             .frame(height: 40)
 
             if isDatePickerPresented {
@@ -155,7 +155,7 @@ extension DateSelectorWidget {
         private var RecordCountBadge: some View {
             ZStack(alignment: .center) {
                 if current {
-                    Color.yellow
+                    self.nav.theme.tint
                 } else {
                     (highlighted ? (active ? Color.white.opacity(0.5) : Theme.secondary) : Color.lightGray())
                 }

--- a/KlockWork/Views/Shared/FilterField.swift
+++ b/KlockWork/Views/Shared/FilterField.swift
@@ -32,6 +32,7 @@ struct FilterOptionPair: Identifiable {
 }
 
 struct FilterFieldView: View {
+    @EnvironmentObject private var state: Navigation
     var filter: FilterField
     var callback: ((FilterField) -> Void)?
 
@@ -43,7 +44,7 @@ struct FilterFieldView: View {
                 Text(filter.name)
                 Image(systemName: "xmark.square.fill")
             }
-            .foregroundStyle(.yellow)
+            .foregroundStyle(self.state.theme.tint)
             .padding(3)
             .background(.white.opacity(0.7).blendMode(.softLight))
             .clipShape(RoundedRectangle(cornerRadius: 3))

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -2,4 +2,4 @@
 
 There are no partners, no vendors, no third parties whatsoever except for Apple involved in the sale and distribution of this app. 
 
-Usage is not tracked. There are no third party libraries, APIs or HTTP requests.
+Usage is not tracked. There are no third party libraries, or APIs. HTTP requests are made to determine if URLs are still active.


### PR DESCRIPTION
* Lists of jobs, projects and companies under Timelines will now set their respective entity as current when tapped, instead of directing you to the edit page.
* Edit button added to context menu for the rows mentioned above.
* App highlight colour is configurable under General settings (please excuse the mess that is the settings page for now)
* New feature: ping links to see if they're still online. This is user configurable, under General settings > `Check if links are online`.
* Updated privacy policy to explain how links are handled.
* Misc bug fixes